### PR TITLE
[BAHIR-85] move getCommandDescription to invoke method

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -111,9 +111,6 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
         this.flinkJedisConfigBase = flinkJedisConfigBase;
 
         this.redisSinkMapper = redisSinkMapper;
-        RedisCommandDescription redisCommandDescription = redisSinkMapper.getCommandDescription();
-        this.redisCommand = redisCommandDescription.getCommand();
-        this.additionalKey = redisCommandDescription.getAdditionalKey();
     }
 
     /**
@@ -126,6 +123,10 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
      */
     @Override
     public void invoke(IN input) throws Exception {
+        RedisCommandDescription redisCommandDescription = redisSinkMapper.getCommandDescription();
+        this.redisCommand = redisCommandDescription.getCommand();
+        this.additionalKey = redisCommandDescription.getAdditionalKey();
+
         String key = redisSinkMapper.getKeyFromData(input);
         String value = redisSinkMapper.getValueFromData(input);
 


### PR DESCRIPTION
REF: https://issues.apache.org/jira/browse/BAHIR-85

Moves `getCommandDescription()` call to inside `invoke()` to allow changes to command key. 

Questions:
1. Do we need to upgrade version?

