### PR TITLE
[BAHIR-93] Correct all version strings to be 1.0-SNAPSHOT

### DIFF
--- a/flink-connector-activemq/README.md
+++ b/flink-connector-activemq/README.md
@@ -8,7 +8,7 @@ To use this connector, add the following dependency to your project:
     <dependency>
       <groupId>org.apache.bahir</groupId>
       <artifactId>flink-connector-activemq_2.11</artifactId>
-      <version>1.0</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
 
 *Version Compatibility*: This module is compatible with ActiveMQ 5.14.0.

--- a/flink-connector-activemq/pom.xml
+++ b/flink-connector-activemq/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.bahir</groupId>
         <artifactId>bahir-flink_parent_2.11</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-connector-akka/README.md
+++ b/flink-connector-akka/README.md
@@ -7,7 +7,7 @@ To use this connector, add the following dependency to your project:
     <dependency>
       <groupId>org.apache.bahir</groupId>
       <artifactId>flink-connector-akka_2.11</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     
 *Version Compatibility*: This module is compatible with Akka 2.0+.

--- a/flink-connector-akka/pom.xml
+++ b/flink-connector-akka/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.bahir</groupId>
         <artifactId>bahir-flink_parent_2.11</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/flink-connector-flume/README.md
+++ b/flink-connector-flume/README.md
@@ -8,7 +8,7 @@ following dependency to your project:
     <dependency>
       <groupId>org.apache.bahir</groupId>
       <artifactId>flink-connector-flume_2.11</artifactId>
-      <version>1.0</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
 
 *Version Compatibility*: This module is compatible with Flume 1.5.0.

--- a/flink-connector-flume/pom.xml
+++ b/flink-connector-flume/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
         <groupId>org.apache.bahir</groupId>
         <artifactId>bahir-flink_parent_2.11</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-connector-netty/README.md
+++ b/flink-connector-netty/README.md
@@ -31,7 +31,7 @@ To use this connector, add the following dependency to your project:
 <dependency>
   <groupId>org.apache.bahir</groupId>
   <artifactId>flink-connector-netty_2.11</artifactId>
-  <version>1.0</version>
+  <version>1.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/flink-connector-netty/pom.xml
+++ b/flink-connector-netty/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.bahir</groupId>
     <artifactId>bahir-flink_parent_2.11</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/flink-connector-redis/README.md
+++ b/flink-connector-redis/README.md
@@ -9,7 +9,7 @@ following dependency to your project:
     <dependency>
       <groupId>org.apache.bahir</groupId>
       <artifactId>flink-connector-redis_2.11</artifactId>
-      <version>1.0</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
 
 *Version Compatibility*: This module is compatible with Redis 2.8.5.

--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.bahir</groupId>
         <artifactId>bahir-flink_parent_2.11</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>org.apache.bahir</groupId>
   <artifactId>bahir-flink_parent_2.11</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Bahir for Apache Flink - Parent POM</name>
   <url>http://bahir.apache.org/</url>
@@ -89,7 +89,7 @@
     <slf4j.version>1.7.16</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
 
-    <!-- Spark version -->
+    <!-- Flink version -->
     <flink.version>1.1.1</flink.version>
 
     <PermGen>64m</PermGen>


### PR DESCRIPTION
According to the discussion in https://www.mail-archive.com/dev@bahir.apache.org/msg00448.html, we will be following a "major.minor" versioning format for bahir-flink, starting from `1.0`.
Therefore, the current state being pre-release of 1.0, the correct version in master should be `1.0-SNAPSHOT`.

This PR corrects all version string occurrences in `bahir-flink`, to prepare it for the upcoming 1.0 release.