### PR TITLE
[BAHIR-91] Upgrade Flink version to 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@
 language: java
 
 env:
-#  - FLINK_VERSION="1.1.0"
-  - FLINK_VERSION="1.1.1"
+  - FLINK_VERSION="1.2.0"
 
 jdk:
   - oraclejdk8

--- a/flink-connector-activemq/pom.xml
+++ b/flink-connector-activemq/pom.xml
@@ -85,6 +85,7 @@ under the License.
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.activemq.tooling</groupId>
             <artifactId>activemq-junit</artifactId>

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
@@ -19,7 +19,10 @@ package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.activemq.internal.AMQExceptionListener;
@@ -97,6 +100,22 @@ public class AMQSourceTest {
         amqSource = new AMQSource<>(config);
         amqSource.setRuntimeContext(createRuntimeContext());
         amqSource.open(new Configuration());
+        amqSource.initializeState(new FunctionInitializationContext() {
+            @Override
+            public boolean isRestored() {
+                return false;
+            }
+
+            @Override
+            public OperatorStateStore getOperatorStateStore() {
+                return mock(OperatorStateStore.class);
+            }
+
+            @Override
+            public KeyedStateStore getKeyedStateStore() {
+                return mock(KeyedStateStore.class);
+            }
+        });
     }
 
     private RuntimeContext createRuntimeContext() {

--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -74,4 +74,15 @@ under the License.
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <inherited>true</inherited>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <log4j.version>1.2.17</log4j.version>
 
     <!-- Flink version -->
-    <flink.version>1.1.1</flink.version>
+    <flink.version>1.2.0</flink.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>


### PR DESCRIPTION
This required some Flink state API updates in the tests. We probably should keep an extra eye on these kind of Flink API changes; the source APIs may be stable, but API changes like these can also break code in bahir-flink. (I suggest a new major version for bahir-flink every time a API break happens from Flink, and as soon as that happens for the first time from now on, we start maintaining a compatibility matrix for bahir-flink).

Note about the additional `maven-bundle-plugin` in the Redis connector:
After the 1.2.0 upgrade, the project had a new dependency to Apacheds JDBM 2.0.0-M2, which packages using the "bundle" type. The plugin helps recognizes the type when building.
