### PR TITLE
[BAHIR-94] Add link to "Linking with Optional Modules" in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The community will review your changes, giving suggestions how to improve the co
 
 ## Building Bahir
 
-Bahir is built using [Apache Maven](http://maven.apache.org/).
+Bahir is built using [Apache Maven](http://maven.apache.org/)™.
 To build Bahir and its example programs, run:
 
     mvn -DskipTests clean install

--- a/flink-connector-activemq/README.md
+++ b/flink-connector-activemq/README.md
@@ -1,9 +1,7 @@
-# Flink ActiveMQ connector
-
+# Flink ActiveMQ Connector
 
 This connector provides a source and sink to [Apache ActiveMQ](http://activemq.apache.org/)™
 To use this connector, add the following dependency to your project:
-
 
     <dependency>
       <groupId>org.apache.bahir</groupId>
@@ -14,6 +12,6 @@ To use this connector, add the following dependency to your project:
 *Version Compatibility*: This module is compatible with ActiveMQ 5.14.0.
 
 Note that the streaming connectors are not part of the binary distribution of Flink. You need to link them into your job jar for cluster execution.
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/linking.html).
 
-
-The source class is called `AMQSource`, the sink is `AMQSink`.
+The source class is called `AMQSource`, and the sink is `AMQSink`.

--- a/flink-connector-akka/README.md
+++ b/flink-connector-akka/README.md
@@ -1,8 +1,7 @@
-# Flink Akka connector
+# Flink Akka Connector
 
 This connector provides a sink to [Akka](http://akka.io/) source actors in an ActorSystem.
 To use this connector, add the following dependency to your project:
-
 
     <dependency>
       <groupId>org.apache.bahir</groupId>
@@ -11,6 +10,9 @@ To use this connector, add the following dependency to your project:
     </dependency>
     
 *Version Compatibility*: This module is compatible with Akka 2.0+.
+
+Note that the streaming connectors are not part of the binary distribution of Flink. You need to link them into your job jar for cluster execution.
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/linking.html).
     
 ## Configuration
     
@@ -28,10 +30,10 @@ A sample configuration can be defined as follows:
     
 ## Message Types
     
-There are 3 different kind of message types which the receiver Actor in flink akka connector can receive.
+There are 3 different kind of message types which the receiver Actor in Flink Akka connector can receive.
     
 - message containing `Iterable<Object>` data
    
 - message containing generic `Object` data
    
-- message containing generic `Object` data and a `Timestamp` value passed as `Tuple2<Object, Long>`.   
+- message containing generic `Object` data and a `Timestamp` value passed as `Tuple2<Object, Long>`.

--- a/flink-connector-flume/README.md
+++ b/flink-connector-flume/README.md
@@ -1,9 +1,7 @@
-# Flink Flume connector
+# Flink Flume Connector
 
-
-This connector provides a Sink that can send data to [Apache Flume](https://flume.apache.org/)™. To use this connector, add the
+This connector provides a sink that can send data to [Apache Flume](https://flume.apache.org/)™. To use this connector, add the
 following dependency to your project:
-
 
     <dependency>
       <groupId>org.apache.bahir</groupId>
@@ -14,7 +12,7 @@ following dependency to your project:
 *Version Compatibility*: This module is compatible with Flume 1.5.0.
 
 Note that the streaming connectors are not part of the binary distribution of Flink. You need to link them into your job jar for cluster execution.
-
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/linking.html).
 
 To create a `FlumeSink` instantiate the following constructor:
 

--- a/flink-connector-netty/README.md
+++ b/flink-connector-netty/README.md
@@ -1,8 +1,11 @@
-#   Flink Netty Connector
+# Flink Netty Connector
 
-This connector provide tcp source and http source for receiving push data, implemented by [Netty](http://netty.io). 
+This connector provides tcp source and http source for receiving push data, implemented by [Netty](http://netty.io). 
 
-##  Data Flow
+Note that the streaming connectors are not part of the binary distribution of Flink. You need to link them into your job jar for cluster execution.
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/linking.html).
+
+## Data Flow
 
 ```
 +-------------+      (2)    +------------------------+
@@ -17,14 +20,14 @@ This connector provide tcp source and http source for receiving push data, imple
 +--------------------+         (1)
 ```
 
-There are three component:
+There are three components:
 
-*   User System - where the data streaming come from
-*   Third Register Service - receive `Flink Netty Source`'s register request(ip and port)
+*   User System - where the data stream is coming from
+*   Third Register Service - receive `Flink Netty Source`'s register request (ip and port)
 *   Flink Netty Source - Netty Server for receiving pushed streaming data from `User System`
 
 
-##   Maven Dependency
+## Maven Dependency
 To use this connector, add the following dependency to your project:
 
 ```
@@ -35,7 +38,7 @@ To use this connector, add the following dependency to your project:
 </dependency>
 ```
 
-##  Usage
+## Usage
 
 *Tcp Source:*
 
@@ -43,7 +46,7 @@ To use this connector, add the following dependency to your project:
 val env = StreamExecutionEnvironment.getExecutionEnvironment
 env.addSource(new TcpReceiverSource("msg", 7070, Some("http://localhost:9090/cb")))
 ```
->paramKey:  the http query param key    
+>paramKey:  the http query param key
 >tryPort:   try to use this point, if this point is used then try a new port
 >callbackUrl:   register connector's ip and port to a `Third Register Service`
 
@@ -53,13 +56,12 @@ env.addSource(new TcpReceiverSource("msg", 7070, Some("http://localhost:9090/cb"
 val env = StreamExecutionEnvironment.getExecutionEnvironment
 env.addSource(new TcpReceiverSource(7070, Some("http://localhost:9090/cb")))
 ```
->tryPort:   try to use this point, if this point is used then try a new port
+>tryPort:   try to use this port, if this point is used then try a new port
 >callbackUrl:   register connector's ip and port to a `Third Register Service`
 
-##  full example 
+## Full Example 
 
-There are two example for get start:
+There are two example to get started:
 
 *   [StreamSqlExample](https://github.com/apache/bahir-flink/blob/master/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala)
 *   [TcpSourceExample](https://github.com/apache/bahir-flink/blob/master/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/TcpSourceExample.scala)
-

--- a/flink-connector-redis/README.md
+++ b/flink-connector-redis/README.md
@@ -1,10 +1,8 @@
-# Flink Redis connector
-
+# Flink Redis Connector
 
 This connector provides a Sink that can write to [Redis](http://redis.io/) and also can publish data 
 to [Redis PubSub](http://redis.io/topics/pubsub). To use this connector, add the
 following dependency to your project:
-
 
     <dependency>
       <groupId>org.apache.bahir</groupId>
@@ -15,7 +13,7 @@ following dependency to your project:
 *Version Compatibility*: This module is compatible with Redis 2.8.5.
 
 Note that the streaming connectors are not part of the binary distribution of Flink. You need to link them into your job jar for cluster execution.
-
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/linking.html).
 
 ## Installing Redis
 


### PR DESCRIPTION
Without this link, Bahir users will most likely bump into questions when trying to include the connectors for Flink cluster execution.

This PR also attempts to improve the overall quality of the Flink
connector docs (typos, extra empty lines, etc.) for the upcoming 1.0
release.