### PR TITLE
[BAHIR-111] Correcting imports of o.a.f.table.api.*

### DIFF
--- a/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala
+++ b/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala
@@ -19,8 +19,8 @@ package org.apache.flink.streaming.connectors.netty.example
 
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.scala._
-import org.apache.flink.api.scala.table._
-import org.apache.flink.api.table.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 
 /**


### PR DESCRIPTION
Issue link: [BAHIR-111: IntelliJ reports compilation error for flink-connector-netty](https://issues.apache.org/jira/browse/BAHIR-111)

Update `StreamSqlExample` in module `flink-connector-netty` to account for package refactoring in Apache Flink, commit [ffe9ec8](https://github.com/apache/flink/commit/ffe9ec8ee1cf73867018e70dd1d35cb1efa267c3): ["[FLINK-4704] [table] Refactor package structure of flink-table"](https://issues.apache.org/jira/browse/FLINK-4704)

This change addresses the following compilation error in IntelliJ:

```
Information:4/24/17, 4:25 PM - Compilation completed with 3 errors and 1 warning in 4s 337ms
Warning:scalac: there was one feature warning; re-run with -feature for details
.../flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala
    Error:Error:line (22)object table is not a member of package org.apache.flink.api.scala
import org.apache.flink.api.scala.table._
    Error:Error:line (23)object table is not a member of package org.apache.flink.api
import org.apache.flink.api.table.TableEnvironment
    Error:Error:line (45)not found: value TableEnvironment
    val tEnv = TableEnvironment.getTableEnvironment(env)
```