### PR TITLE
[BAHIR-129] Upgrade Flink version to 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,22 +46,14 @@ matrix:
       env:
         - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
         - CACHE_NAME=JDK8_F130_D
-    - jdk: oraclejdk7
+    - jdk: openjdk7
       env:
         - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
         - CACHE_NAME=JDK7_F130_A
-    - jdk: oraclejdk7
+    - jdk: openjdk7
       env:
         - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
         - CACHE_NAME=JDK7_F130_B
-    - jdk: openjdk7
-      env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
-        - CACHE_NAME=JDK7_F130_C
-    - jdk: openjdk7
-      env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
-        - CACHE_NAME=JDK7_F130_D
 
 before_install:
   - ./dev/change-scala-version.sh $SCALA_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,28 +31,37 @@ language: java
 matrix:
   include:
     - jdk: oraclejdk8
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - CACHE_NAME=JDK8_F130_A
     - jdk: oraclejdk8
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - CACHE_NAME=JDK8_F130_B
     - jdk: openjdk8
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - CACHE_NAME=JDK8_F130_C
     - jdk: openjdk8
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - CACHE_NAME=JDK8_F130_D
     - jdk: oraclejdk7
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - CACHE_NAME=JDK7_F130_A
     - jdk: oraclejdk7
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - CACHE_NAME=JDK7_F130_B
     - jdk: openjdk7
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
-
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - CACHE_NAME=JDK7_F130_C
     - jdk: openjdk7
-      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+      env:
+        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - CACHE_NAME=JDK7_F130_D
 
 before_install:
   - ./dev/change-scala-version.sh $SCALA_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,31 +15,48 @@
 # limitations under the License.
 #
 
+sudo: required
+dist: trusty
+
+cache:
+  directories:
+  - $HOME/.m2
+
+# do not cache our own artifacts
+before_cache:
+  - rm -rf $HOME/.m2/repository/org/apache/flink/
+
 language: java
 
 matrix:
   include:
     - jdk: oraclejdk8
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.11"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
 
     - jdk: oraclejdk8
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.10"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+
+    - jdk: openjdk8
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+
+    - jdk: openjdk8
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
 
     - jdk: oraclejdk7
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.11"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
 
     - jdk: oraclejdk7
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.10"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
 
     - jdk: openjdk7
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.11"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
 
     - jdk: openjdk7
-      env: FLINK_VERSION="1.2.0" SCALA_VER="2.10"
+      env: FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
 
 before_install:
-  - ./dev/change-scala-version.sh $SCALA_VER
+  - ./dev/change-scala-version.sh $SCALA_VERSION
 
 install: true
 
-script: mvn clean verify -Pscala-$SCALA_VER -Dflink.version=$FLINK_VERSION
+script: mvn clean verify -Pscala-$SCALA_VERSION -Dflink.version=$FLINK_VERSION

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSinkTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSinkTest.java
@@ -115,6 +115,7 @@ public class AMQSinkTest {
         verify(session).createTopic(DESTINATION_NAME);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void exceptionOnSendAreNotThrown() throws Exception {
         when(session.createBytesMessage()).thenThrow(JMSException.class);
@@ -123,6 +124,7 @@ public class AMQSinkTest {
         amqSink.invoke("msg");
     }
 
+    @SuppressWarnings("unchecked")
     @Test(expected = RuntimeException.class)
     public void exceptionOnSendAreThrownByDefault() throws Exception {
         when(session.createBytesMessage()).thenThrow(JMSException.class);

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
@@ -72,6 +72,7 @@ public class AMQSourceTest {
     private SimpleStringSchema deserializationSchema;
     SourceFunction.SourceContext<String> context;
 
+    @SuppressWarnings("unchecked")
     @Before
     public void before() throws Exception {
         connectionFactory = mock(ActiveMQConnectionFactory.class);

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
@@ -254,6 +254,11 @@ public class ActiveMQConnectorITCase {
         public void emitWatermark(Watermark mark) { }
 
         @Override
+        public void markAsTemporarilyIdle() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public Object getCheckpointLock() {
             return contextLock;
         }

--- a/flink-connector-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
+++ b/flink-connector-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
@@ -237,6 +237,11 @@ public class AkkaSourceTest {
     }
 
     @Override
+    public void markAsTemporarilyIdle() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Object getCheckpointLock() {
       return lock;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <log4j.version>1.2.17</log4j.version>
 
     <!-- Flink version -->
-    <flink.version>1.2.0</flink.version>
+    <flink.version>1.3.0</flink.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>


### PR DESCRIPTION
Upgrade Flink version from 1.2.0 to 1.3.0.

## Brief change log
- travis build, remove oraclejdk7(  [Travis: oraclejdk7 is not available anymore](https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879)) and add openjdk8.
- travis build, define unique CACHE_NAME in case the auto-generated ones are not unique.
- upgrade flink version, fix It brings the problems.

## Verifying this change
- Travis build has passed。