### PR TITLE
[BAHIR-145] Fix the JedisCluster function called when performing PFADD

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -137,7 +137,7 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
     @Override
     public void pfadd(final String key, final String element) {
         try {
-            jedisCluster.set(key, element);
+            jedisCluster.pfadd(key, element);
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Cannot send Redis message with command PFADD to key {} error message {}",


### PR DESCRIPTION
Hi All,

As described in the bug report, there is a bug in the Streaming Flink connector for Redis (Cluster). The connector cannot perform PFADD correctly because of a wrong function call. Please check this fix.

Best regards,
Phiradet