### PR TITLE
[BAHIR-173]Update Flink version to 1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,10 @@ matrix:
       env:
         - FLINK_VERSION="1.5.1" SCALA_VERSION="2.11"
         - CACHE_NAME=JDK8_F130_A
-    - jdk: oraclejdk8
-      env:
-        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.10"
-        - CACHE_NAME=JDK8_F130_B
     - jdk: openjdk8
       env:
         - FLINK_VERSION="1.5.1" SCALA_VERSION="2.11"
         - CACHE_NAME=JDK8_F130_C
-    - jdk: openjdk8
-      env:
-        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.10"
-        - CACHE_NAME=JDK8_F130_D
 
 before_install:
   - ./dev/change-scala-version.sh $SCALA_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,19 +32,19 @@ matrix:
   include:
     - jdk: oraclejdk8
       env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.11"
         - CACHE_NAME=JDK8_F130_A
     - jdk: oraclejdk8
       env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.10"
         - CACHE_NAME=JDK8_F130_B
     - jdk: openjdk8
       env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.11"
+        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.11"
         - CACHE_NAME=JDK8_F130_C
     - jdk: openjdk8
       env:
-        - FLINK_VERSION="1.3.0" SCALA_VERSION="2.10"
+        - FLINK_VERSION="1.5.1" SCALA_VERSION="2.10"
         - CACHE_NAME=JDK8_F130_D
 
 before_install:

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSink.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSink.java
@@ -18,10 +18,10 @@
 package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.connectors.activemq.internal.AMQUtil;
-import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +128,7 @@ public class AMQSink<IN> extends RichSinkFunction<IN> {
      *            The incoming data
      */
     @Override
-    public void invoke(IN value) {
+    public void invoke(IN value, Context context) throws Exception {
         try {
             byte[] bytes = serializationSchema.serialize(value);
             BytesMessage message = session.createBytesMessage();

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSinkConfig.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSinkConfig.java
@@ -17,7 +17,7 @@
 package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.flink.streaming.util.serialization.SerializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.util.Preconditions;
 
 /**

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
@@ -40,7 +40,7 @@ import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Source for reading messages from an ActiveMQ queue.
@@ -191,7 +191,7 @@ public class AMQSource<OUT> extends MessageAcknowledgingSourceBase<OUT, String>
     }
 
     @Override
-    protected void acknowledgeIDs(long checkpointId, List<String> UIds) {
+    protected void acknowledgeIDs(long l, Set<String> UIds) {
         try {
             for (String messageId : UIds) {
                 Message unacknowledgedMessage = unacknowledgedMessages.get(messageId);

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.activemq;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
@@ -28,7 +29,6 @@ import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.activemq.internal.AMQExceptionListener;
 import org.apache.flink.streaming.connectors.activemq.internal.AMQUtil;
 import org.apache.flink.streaming.connectors.activemq.internal.RunningChecker;
-import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -191,7 +191,7 @@ public class AMQSource<OUT> extends MessageAcknowledgingSourceBase<OUT, String>
     }
 
     @Override
-    protected void acknowledgeIDs(long l, Set<String> UIds) {
+    protected void acknowledgeIDs(long checkpointId, Set<String> UIds) {
         try {
             for (String messageId : UIds) {
                 Message unacknowledgedMessage = unacknowledgedMessages.get(messageId);

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSourceConfig.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSourceConfig.java
@@ -17,8 +17,8 @@
 package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.connectors.activemq.internal.RunningChecker;
-import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.util.Preconditions;
 
 /**

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSinkTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSinkTest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.util.serialization.SerializationSchema;
-import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,7 +83,7 @@ public class AMQSinkTest {
     @Test
     public void messageSentToProducer() throws Exception {
         byte[] expectedMessage = serializationSchema.serialize("msg");
-        amqSink.invoke("msg");
+        amqSink.invoke("msg", null);
 
         verify(producer).send(message);
         verify(message).writeBytes(expectedMessage);
@@ -121,7 +121,7 @@ public class AMQSinkTest {
         when(session.createBytesMessage()).thenThrow(JMSException.class);
         amqSink.setLogFailuresOnly(true);
 
-        amqSink.invoke("msg");
+        amqSink.invoke("msg", null);
     }
 
     @SuppressWarnings("unchecked")
@@ -129,7 +129,7 @@ public class AMQSinkTest {
     public void exceptionOnSendAreThrownByDefault() throws Exception {
         when(session.createBytesMessage()).thenThrow(JMSException.class);
 
-        amqSink.invoke("msg");
+        amqSink.invoke("msg", null);
     }
 
     @Test

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.activemq;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.configuration.Configuration;
@@ -27,7 +28,6 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.activemq.internal.AMQExceptionListener;
 import org.apache.flink.streaming.connectors.activemq.internal.RunningChecker;
-import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQSourceTest.java
@@ -161,7 +161,7 @@ public class AMQSourceTest {
     @Test
     public void acknowledgeReceivedMessage() throws Exception {
         amqSource.run(context);
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList(MSG_ID));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton(MSG_ID));
 
         verify(message).acknowledge();
     }
@@ -169,7 +169,7 @@ public class AMQSourceTest {
     @Test
     public void handleUnknownIds() throws Exception {
         amqSource.run(context);
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList("unknown-id"));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton("unknown-id"));
 
         verify(message, never()).acknowledge();
     }
@@ -177,8 +177,8 @@ public class AMQSourceTest {
     @Test
     public void doNotAcknowledgeMessageTwice() throws Exception {
         amqSource.run(context);
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList(MSG_ID));
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList(MSG_ID));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton(MSG_ID));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton(MSG_ID));
 
         verify(message, times(1)).acknowledge();
     }
@@ -196,7 +196,7 @@ public class AMQSourceTest {
         doThrow(JMSException.class).when(message).acknowledge();
 
         amqSource.run(context);
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList(MSG_ID));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton(MSG_ID));
     }
 
     @Test
@@ -206,7 +206,7 @@ public class AMQSourceTest {
         doThrow(JMSException.class).when(message).acknowledge();
 
         amqSource.run(context);
-        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singletonList(MSG_ID));
+        amqSource.acknowledgeIDs(CHECKPOINT_ID, Collections.singleton(MSG_ID));
     }
 
     @Test

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
@@ -74,7 +74,7 @@ public class ActiveMQConnectorITCase {
     public static void afterClass() {
         flinkPort = -1;
         if (flink != null) {
-            flink.shutdown();
+            flink.startInternalShutdown();
         }
     }
 

--- a/flink-connector-akka/pom.xml
+++ b/flink-connector-akka/pom.xml
@@ -35,10 +35,15 @@ under the License.
 
     <properties>
         <mockito.version>1.10.19</mockito.version>
-        <akka.version>2.3.15</akka.version>
+        <akka.version>2.4.20</akka.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>

--- a/flink-connector-akka/src/main/java/org/apache/flink/streaming/connectors/akka/AkkaSource.java
+++ b/flink-connector-akka/src/main/java/org/apache/flink/streaming/connectors/akka/AkkaSource.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.akka.utils.ReceiverActor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 
 import java.util.Collections;
 
@@ -95,7 +97,7 @@ public class AkkaSource extends RichSourceFunction<Object>
       Props.create(classForActor, ctx, urlOfPublisher, autoAck), actorName);
 
     LOG.info("Started the Receiver actor {} successfully", actorName);
-    receiverActorSystem.awaitTermination();
+    Await.result(receiverActorSystem.whenTerminated(), Duration.Inf());
   }
 
   @Override
@@ -103,7 +105,7 @@ public class AkkaSource extends RichSourceFunction<Object>
     LOG.info("Closing source");
     if (receiverActorSystem != null) {
       receiverActor.tell(PoisonPill.getInstance(), ActorRef.noSender());
-      receiverActorSystem.shutdown();
+      receiverActorSystem.terminate();
     }
   }
 

--- a/flink-connector-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
+++ b/flink-connector-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
@@ -34,6 +34,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import scala.concurrent.Await;
+import scala.concurrent.duration.Duration;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -80,8 +82,8 @@ public class AkkaSourceTest {
 
   @After
   public void afterTest() throws Exception {
-    feederActorSystem.shutdown();
-    feederActorSystem.awaitTermination();
+    feederActorSystem.terminate();
+    Await.result(feederActorSystem.whenTerminated(), Duration.Inf());
 
     source.cancel();
     sourceThread.join();

--- a/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
+++ b/flink-connector-flume/src/main/java/org/apache/flink/streaming/connectors/flume/FlumeSink.java
@@ -17,10 +17,10 @@
 
 package org.apache.flink.streaming.connectors.flume;
 
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
@@ -55,8 +55,7 @@ public class FlumeSink<IN> extends RichSinkFunction<IN> {
      *            The tuple arriving from the datastream
      */
     @Override
-    public void invoke(IN value) {
-
+    public void invoke(IN value, Context context) throws Exception {
         byte[] data = schema.serialize(value);
         client.sendDataToFlume(data);
 

--- a/flink-connector-influxdb/src/main/java/org/apache/flink/streaming/connectors/influxdb/InfluxDBSink.java
+++ b/flink-connector-influxdb/src/main/java/org/apache/flink/streaming/connectors/influxdb/InfluxDBSink.java
@@ -76,7 +76,7 @@ public class InfluxDBSink extends RichSinkFunction<InfluxDBPoint> {
      * @param dataPoint {@link InfluxDBPoint}
      */
     @Override
-    public void invoke(InfluxDBPoint dataPoint) throws Exception {
+    public void invoke(InfluxDBPoint dataPoint, Context context) throws Exception {
         if (StringUtils.isNullOrWhitespaceOnly(dataPoint.getMeasurement())) {
             throw new RuntimeException("No measurement defined");
         }

--- a/flink-connector-netty/src/main/scala/org/apache/flink/streaming/connectors/netty/example/NettyUtil.scala
+++ b/flink-connector-netty/src/main/scala/org/apache/flink/streaming/connectors/netty/example/NettyUtil.scala
@@ -21,7 +21,6 @@ import java.io.{BufferedReader, InputStreamReader}
 import java.net._
 
 import org.apache.commons.lang3.SystemUtils
-import org.mortbay.util.MultiException
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -153,8 +152,6 @@ object NettyUtil {
     exception match {
       case e: BindException if e.getMessage != null => true
       case e: BindException => isBindCollision(e.getCause)
-      case e: MultiException =>
-        e.getThrowables.asScala.toList.map(_.asInstanceOf[Throwable]).exists(isBindCollision)
       case e: Exception => isBindCollision(e.getCause)
       case _ => false
     }

--- a/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala
+++ b/flink-connector-netty/src/test/scala/org/apache/flink/streaming/connectors/netty/example/StreamSqlExample.scala
@@ -60,9 +60,9 @@ object StreamSqlExample {
     tEnv.registerDataStream("OrderA", orderA, 'user, 'product, 'amount)
 
     // union the two tables
-    val result = tEnv.sql("SELECT STREAM * FROM OrderA WHERE amount > 2")
+    val result = tEnv.sqlQuery("SELECT STREAM * FROM OrderA WHERE amount > 2")
 
-    result.toDataStream[Order].print()
+    result.toAppendStream[Order].print()
 
     env.execute()
   }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/RedisSink.java
@@ -26,8 +26,8 @@ import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisSenti
 import org.apache.flink.streaming.connectors.redis.common.container.RedisCommandsContainer;
 import org.apache.flink.streaming.connectors.redis.common.container.RedisCommandsContainerBuilder;
 import org.apache.flink.streaming.connectors.redis.common.mapper.RedisCommand;
-import org.apache.flink.streaming.connectors.redis.common.mapper.RedisDataType;
 import org.apache.flink.streaming.connectors.redis.common.mapper.RedisCommandDescription;
+import org.apache.flink.streaming.connectors.redis.common.mapper.RedisDataType;
 import org.apache.flink.streaming.connectors.redis.common.mapper.RedisMapper;
 
 import org.slf4j.Logger;
@@ -125,7 +125,7 @@ public class RedisSink<IN> extends RichSinkFunction<IN> {
      * @param input The incoming data
      */
     @Override
-    public void invoke(IN input) throws Exception {
+    public void invoke(IN input, Context context) throws Exception {
         String key = redisSinkMapper.getKeyFromData(input);
         String value = redisSinkMapper.getValueFromData(input);
 

--- a/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisITCaseBase.java
+++ b/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisITCaseBase.java
@@ -16,7 +16,7 @@
  */
 package org.apache.flink.streaming.connectors.redis;
 
-import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import redis.embedded.RedisServer;
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import static org.apache.flink.util.NetUtils.getAvailablePort;
 
-public abstract class RedisITCaseBase extends StreamingMultipleProgramsTestBase {
+public abstract class RedisITCaseBase extends AbstractTestBase {
 
     public static final int REDIS_PORT = getAvailablePort();
     public static final String REDIS_HOST = "127.0.0.1";

--- a/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamInMemOutputHandler.java
+++ b/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamInMemOutputHandler.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.streaming.siddhi.utils.SiddhiTupleFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.slf4j.Logger;
@@ -31,8 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.query.api.definition.AbstractDefinition;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Siddhi Stream output callback handler and conver siddhi {@link Event} to required output type,

--- a/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamOutputHandler.java
+++ b/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamOutputHandler.java
@@ -17,11 +17,11 @@
 
 package org.apache.flink.streaming.siddhi.operator;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.streaming.siddhi.utils.SiddhiTupleFactory;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;

--- a/flink-library-siddhi/src/test/java/org/apache/flink/streaming/siddhi/SiddhiCEPITCase.java
+++ b/flink-library-siddhi/src/test/java/org/apache/flink/streaming/siddhi/SiddhiCEPITCase.java
@@ -41,7 +41,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
 import org.apache.flink.streaming.api.operators.StreamMap;
-import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Flink-siddhi library integration test cases
  */
-public class SiddhiCEPITCase extends StreamingMultipleProgramsTestBase implements Serializable {
+public class SiddhiCEPITCase extends AbstractTestBase implements Serializable {
 
     @Rule
     public transient TemporaryFolder tempFolder = new TemporaryFolder();

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <log4j.version>1.2.17</log4j.version>
 
     <!-- Flink version -->
-    <flink.version>1.3.0</flink.version>
+    <flink.version>1.5.1</flink.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>

--- a/pom.xml
+++ b/pom.xml
@@ -704,40 +704,6 @@
         <module>distribution</module>
       </modules>
     </profile>
-
-    <profile>
-      <id>scala-2.10</id>
-      <properties>
-        <scala.version>2.10.5</scala.version>
-        <scala.binary.version>2.10</scala.binary.version>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-versions</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <bannedDependencies>
-                      <excludes combine.children="append">
-                        <exclude>*:*_2.11</exclude>
-                      </excludes>
-                    </bannedDependencies>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>scala-2.11</id>
       <activation>


### PR DESCRIPTION
This PR updates the version of Flink to the last official release 1.5.1. 
This update required updating akka version in `flink-connector-akka` module.
`MultiException` was removed since it was imported directly from Flink and is not present in Flink 1.5.1. 