### PR TITLE
[BAHIR-202] Improve KuduSink throughput by using async FlushMode

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduOutputFormat.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduOutputFormat.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.connectors.kudu.connector.KuduRow;
 import org.apache.flink.streaming.connectors.kudu.connector.KuduTableInfo;
 import org.apache.flink.streaming.connectors.kudu.serde.KuduSerialization;
 import org.apache.flink.util.Preconditions;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,9 @@ import java.io.IOException;
 
 public class KuduOutputFormat<OUT> extends RichOutputFormat<OUT> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
+    private static final long serialVersionUID = 1L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
 
     private String kuduMasters;
     private KuduTableInfo tableInfo;
@@ -87,7 +90,7 @@ public class KuduOutputFormat<OUT> extends RichOutputFormat<OUT> {
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
         if (connector != null) return;
-        connector = new KuduConnector(kuduMasters, tableInfo, consistency, writeMode);
+        connector = new KuduConnector(kuduMasters, tableInfo, consistency, writeMode,FlushMode.AUTO_FLUSH_SYNC);
         serializer = serializer.withSchema(tableInfo.getSchema());
     }
 

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduOutputFormat.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduOutputFormat.java
@@ -33,7 +33,7 @@ public class KuduOutputFormat<OUT> extends RichOutputFormat<OUT> {
 
     private static final long serialVersionUID = 1L;
 
-	private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
 
     private String kuduMasters;
     private KuduTableInfo tableInfo;

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduSink.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduSink.java
@@ -37,7 +37,7 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
 
     private static final long serialVersionUID = 1L;
 
-	private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KuduOutputFormat.class);
 
     private String kuduMasters;
     private KuduTableInfo tableInfo;
@@ -89,12 +89,12 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
         this.flushMode = FlushMode.AUTO_FLUSH_SYNC;
         return this;
     }
-    
+
     public KuduSink<OUT> withAsyncFlushMode() {
         this.flushMode = FlushMode.AUTO_FLUSH_BACKGROUND;
         return this;
     }
-    
+
     @Override
     public void open(Configuration parameters) throws IOException {
         if (this.connector != null) return;
@@ -103,10 +103,13 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
     }
     
     /**
-     * if flink checkpoint is disable,synchronously write data to kudu.
-     * if flink checkpoint is enable, asynchronously write data to kudu by default.
-     * (Note: async may result in out-of-order writes to Kudu. 
-     *  you also can change to sync by explicitly calling withSyncFlushMode() when initializing KuduSink. )
+     * If flink checkpoint is disable,synchronously write data to kudu.
+     * <p>If flink checkpoint is enable, asynchronously write data to kudu by default.
+     *
+     * <p>(Note: async may result in out-of-order writes to Kudu.
+     *  you also can change to sync by explicitly calling {@link KuduSink#withSyncFlushMode()} when initializing KuduSink. )
+     *
+     * @return flushMode
      */
     private FlushMode getflushMode() {
         FlushMode flushMode = FlushMode.AUTO_FLUSH_SYNC;
@@ -119,7 +122,7 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
         }
         return flushMode;
     }
-    
+
     @Override
     public void invoke(OUT row) throws Exception {
         KuduRow kuduRow = serializer.serialize(row);
@@ -140,15 +143,15 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
         }
     }
 
-	@Override
+    @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
     }
 
-	@Override
+    @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("Snapshotting state {} ...", context.getCheckpointId());
+            LOG.debug("Snapshotting state {} ...", context.getCheckpointId());
         }
-		this.connector.flush();
+        this.connector.flush();
     }
 }

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduSink.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/KuduSink.java
@@ -101,7 +101,7 @@ public class KuduSink<OUT> extends RichSinkFunction<OUT> implements Checkpointed
         this.connector = new KuduConnector(kuduMasters, tableInfo, consistency, writeMode, getflushMode());
         this.serializer.withSchema(tableInfo.getSchema());
     }
-    
+
     /**
      * If flink checkpoint is disable,synchronously write data to kudu.
      * <p>If flink checkpoint is enable, asynchronously write data to kudu by default.

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
@@ -134,11 +134,11 @@ public class KuduConnector implements AutoCloseable {
             Thread.sleep(Time.seconds(pendingTransactions.get()).toMilliseconds());
         }
 
-        if (client == null) return;
-        client.close();
-        
         if (session == null) return;
         session.close();
+        
+        if (client == null) return;
+        client.close();
     }
 
     public void flush(){

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
@@ -18,9 +18,11 @@ package org.apache.flink.streaming.connectors.kudu.connector;
 
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.api.common.time.Time;
 import org.apache.kudu.client.*;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ public class KuduConnector implements AutoCloseable {
 
     private AsyncKuduClient client;
     private KuduTable table;
+    private AsyncKuduSession session;
 
     private Consistency consistency;
     private WriteMode writeMode;
@@ -48,15 +51,17 @@ public class KuduConnector implements AutoCloseable {
     private static AtomicBoolean errorTransactions = new AtomicBoolean(false);
 
     public KuduConnector(String kuduMasters, KuduTableInfo tableInfo) throws IOException {
-        this(kuduMasters, tableInfo, KuduConnector.Consistency.STRONG, KuduConnector.WriteMode.UPSERT);
+        this(kuduMasters, tableInfo, KuduConnector.Consistency.STRONG, KuduConnector.WriteMode.UPSERT,FlushMode.AUTO_FLUSH_SYNC);
     }
 
-    public KuduConnector(String kuduMasters, KuduTableInfo tableInfo, Consistency consistency, WriteMode writeMode) throws IOException {
+    public KuduConnector(String kuduMasters, KuduTableInfo tableInfo, Consistency consistency, WriteMode writeMode,FlushMode flushMode) throws IOException {
         this.client = client(kuduMasters);
         this.table = table(tableInfo);
+        this.session = client.newSession();
         this.consistency = consistency;
         this.writeMode = writeMode;
         this.defaultCB = new ResponseCallback();
+        this.session.setFlushMode(flushMode);
     }
 
     private AsyncKuduClient client(String kuduMasters) {
@@ -105,11 +110,10 @@ public class KuduConnector implements AutoCloseable {
 
         return tokenBuilder.build();
     }
-
+    
     public boolean writeRow(KuduRow row) throws Exception {
         final Operation operation = KuduMapper.toOperation(table, writeMode, row);
 
-        AsyncKuduSession session = client.newSession();
         Deferred<OperationResponse> response = session.apply(operation);
 
         if (KuduConnector.Consistency.EVENTUAL.equals(consistency)) {
@@ -119,7 +123,6 @@ public class KuduConnector implements AutoCloseable {
             processResponse(response.join());
         }
 
-        session.close();
         return !errorTransactions.get();
 
     }
@@ -133,8 +136,15 @@ public class KuduConnector implements AutoCloseable {
 
         if (client == null) return;
         client.close();
+        
+        if (session == null) return;
+        session.close();
     }
 
+    public void flush(){
+    	this.session.flush();
+    }
+    
     private class ResponseCallback implements Callback<Boolean, OperationResponse> {
         @Override
         public Boolean call(OperationResponse operationResponse) {

--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
@@ -110,7 +110,7 @@ public class KuduConnector implements AutoCloseable {
 
         return tokenBuilder.build();
     }
-    
+
     public boolean writeRow(KuduRow row) throws Exception {
         final Operation operation = KuduMapper.toOperation(table, writeMode, row);
 
@@ -136,15 +136,15 @@ public class KuduConnector implements AutoCloseable {
 
         if (session == null) return;
         session.close();
-        
+
         if (client == null) return;
         client.close();
     }
 
     public void flush(){
-    	this.session.flush();
+        this.session.flush();
     }
-    
+
     private class ResponseCallback implements Callback<Boolean, OperationResponse> {
         @Override
         public Boolean call(OperationResponse operationResponse) {


### PR DESCRIPTION
change is that:
1. Default , KuduSink processing message one by one without checkpoint.
2. when we enable checkpoint , We improve kuduSink throughput by using ```FlushMode.AUTO_FLUSH_BACKGROUND``` , and using checkpoint to ensure at-least-once. 