### PR TITLE
[BAHIR-177] Fixed state recovery for Flink and fixed size of the reco…

### DIFF
--- a/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
+++ b/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
@@ -236,7 +236,7 @@ public abstract class SiddhiStream {
             TypeInformation<T> typeInformation =
                 SiddhiTypeFactory.getTupleTypeInformation(siddhiContext.getFinalExecutionPlan(), outStreamId);
             siddhiContext.setOutputStreamType(typeInformation);
-            return returnsInternal(siddhiContext);
+            return returnsInternal(siddhiContext, outStreamId);
         }
 
         /**
@@ -269,11 +269,11 @@ public abstract class SiddhiStream {
             siddhiContext.setOutputStreamType(typeInformation);
             siddhiContext.setExtensions(environment.getExtensions());
             siddhiContext.setExecutionConfig(environment.getExecutionEnvironment().getConfig());
-            return returnsInternal(siddhiContext);
+            return returnsInternal(siddhiContext, outStreamId);
         }
 
-        private <T> DataStream<T> returnsInternal(SiddhiOperatorContext siddhiContext) {
-            return SiddhiStreamFactory.createDataStream(siddhiContext, this.dataStream);
+        private <T> DataStream<T> returnsInternal(SiddhiOperatorContext siddhiContext, String outStreamId) {
+            return SiddhiStreamFactory.createDataStream(siddhiContext, this.dataStream, outStreamId);
         }
     }
 }

--- a/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/SiddhiStreamOperator.java
+++ b/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/operator/SiddhiStreamOperator.java
@@ -36,8 +36,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  */
 public class SiddhiStreamOperator<IN, OUT> extends AbstractSiddhiOperator<Tuple2<String, IN>, OUT> {
 
-    public SiddhiStreamOperator(SiddhiOperatorContext siddhiPlan) {
-        super(siddhiPlan);
+    public SiddhiStreamOperator(SiddhiOperatorContext siddhiPlan, String operatorName) {
+        super(siddhiPlan, operatorName);
     }
 
     @Override
@@ -68,9 +68,10 @@ public class SiddhiStreamOperator<IN, OUT> extends AbstractSiddhiOperator<Tuple2
 
     @Override
     protected PriorityQueue<StreamRecord<Tuple2<String, IN>>> restoreQueuerState(DataInputView dataInputView) throws IOException {
-        int sizeOfQueue = dataInputView.readInt();
+        int snapshotSize = dataInputView.readInt();
+        int sizeOfQueue = snapshotSize > 0 ? snapshotSize : this.INITIAL_PRIORITY_QUEUE_CAPACITY;
         PriorityQueue<StreamRecord<Tuple2<String, IN>>> priorityQueue = new PriorityQueue<>(sizeOfQueue);
-        for (int i = 0; i < sizeOfQueue; i++) {
+        for (int i = 0; i < snapshotSize; i++) {
             String streamId = dataInputView.readUTF();
             StreamElement streamElement = getStreamRecordSerializer(streamId).deserialize(dataInputView);
             priorityQueue.offer(streamElement.<Tuple2<String, IN>>asRecord());

--- a/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiStreamFactory.java
+++ b/flink-library-siddhi/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiStreamFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  */
 public class SiddhiStreamFactory {
     @SuppressWarnings("unchecked")
-    public static <OUT> DataStream<OUT> createDataStream(SiddhiOperatorContext context, DataStream<Tuple2<String, Object>> namedStream) {
-        return namedStream.transform(context.getName(), context.getOutputStreamType(), new SiddhiStreamOperator(context));
+    public static <OUT> DataStream<OUT> createDataStream(SiddhiOperatorContext context, DataStream<Tuple2<String, Object>> namedStream, String outStreamId) {
+        return namedStream.transform(context.getName(), context.getOutputStreamType(), new SiddhiStreamOperator(context,outStreamId));
     }
 }


### PR DESCRIPTION
Two issues are meant to be fixed in this PR:
1) As described in BAHIR-177 currently the state recovery of Bahir operators depends on randomly generated IDs, which basically makes it impossible to recover state properly. The chagne has been done, so that the `outStreamId` is used instead of random names.
2) The size of the queue recovered in `restoreQueuerState()` was equal to the actual size (number of elements) of the snapshot queue. If the queue was empty, the method would try to create queue with the size 0, which is currently forbidden for the `PriorityQueue` in Java.