### PR TITLE
[BAHIR-204] [activemq] ActiveMQ Source only emits previously unproce…

### DIFF
--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
@@ -226,10 +226,11 @@ public class AMQSource<OUT> extends MessageAcknowledgingSourceBase<OUT, String>
             bytesMessage.readBytes(bytes);
             OUT value = deserializationSchema.deserialize(bytes);
             synchronized (ctx.getCheckpointLock()) {
-                ctx.collect(value);
-                if (!autoAck) {
-                    addId(bytesMessage.getJMSMessageID());
+                if (!autoAck && addId(bytesMessage.getJMSMessageID())) {
+                    ctx.collect(value);
                     unacknowledgedMessages.put(bytesMessage.getJMSMessageID(), bytesMessage);
+                } else {
+                    ctx.collect(value);
                 }
             }
         }


### PR DESCRIPTION
ActiveMQ Source only emits previously unprocessed records now. Previously, it was possible that this source duplicates records if the Flink job failed between snapshotState and notifyOnCheckpointComplete