### PR TITLE
[BAHIR-190] [activemq] Fixed premature exit on empty queue

### DIFF
--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQSource.java
@@ -219,7 +219,7 @@ public class AMQSource<OUT> extends MessageAcknowledgingSourceBase<OUT, String>
             Message message = consumer.receive(1000);
             if (! (message instanceof BytesMessage)) {
                 LOG.warn("Active MQ source received non bytes message: {}", message);
-                return;
+                continue;
             }
             BytesMessage bytesMessage = (BytesMessage) message;
             byte[] bytes = new byte[(int) bytesMessage.getBodyLength()];


### PR DESCRIPTION
**Fixes**: When the source queue has no more messages, the job doesn't exit anymore. This was a problem with ActiveMQ.


Note: The [original JIRA issue](https://issues.apache.org/jira/browse/BAHIR-190) wasn't created by me.