### PR TITLE
Add missing placeholder for log message

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -62,8 +62,8 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
             jedisCluster.hset(key, hashField, value);
         } catch (Exception e) {
             if (LOG.isErrorEnabled()) {
-                LOG.error("Cannot send Redis message with command HSET to hash {} error message {}",
-                    key, hashField, e.getMessage());
+                LOG.error("Cannot send Redis message with command HSET to hash {} of key {} error message {}",
+                    hashField, key, e.getMessage());
             }
             throw e;
         }


### PR DESCRIPTION
The log message 
```Cannot send Redis message with command HSET to hash {} error message {}```
 missed a placeholder as we passed three arguments for it. 