### PR TITLE
BAHIR-85: make it possible to change additional key without restarting

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisMapper.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/RedisMapper.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.redis.common.mapper;
 import org.apache.flink.api.common.functions.Function;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * Function that creates the description how the input data should be mapped to redis type.
@@ -63,4 +64,15 @@ public interface RedisMapper<T> extends Function, Serializable {
      * @return value
      */
     String getValueFromData(T data);
+
+    /**
+     * Extracts the additional key from data as an {@link Optional<String>}.
+     * The default implementation returns an empty Optional.
+     *
+     * @param data
+     * @return Optional
+     */
+    default Optional<String> getAdditionalKey(T data) {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
We have a use case where we want to sink data to Redis as hashes, but have the hashes stored under different keys which are also extracted from the data. This change makes this possible in a backward compatible manner (see my comment in https://issues.apache.org/jira/browse/BAHIR-85 for details).