### PR TITLE
Bug fix: When auto create table throw table already exists exception

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/streaming/connectors/kudu/connector/KuduConnector.java
@@ -76,7 +76,14 @@ public class KuduConnector implements AutoCloseable {
             return syncClient.openTable(tableName);
         }
         if (infoTable.createIfNotExist()) {
-            return syncClient.createTable(tableName, infoTable.getSchema(), infoTable.getCreateTableOptions());
+            try {
+                return syncClient.createTable(tableName, infoTable.getSchema(), infoTable.getCreateTableOptions());
+            }catch (KuduException ke){
+                if (ke.getMessage().contains("already exists with id ")) {
+                    return syncClient.openTable(tableName);
+                }
+                throw ke;
+            }
         }
         throw new UnsupportedOperationException("table not exists and is marketed to not be created");
     }


### PR DESCRIPTION
org.apache.kudu.client.NonRecoverableException: table XXX already exists with id 397a3d7fba9843a1b3b6498158108b78