### PR TITLE
fix bug "the client has already been closed"

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/batch/KuduInputFormat.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/batch/KuduInputFormat.java
@@ -98,6 +98,7 @@ public class KuduInputFormat<OUT> extends RichInputFormat<OUT, KuduInputSplit> {
         }
         if (kuduReader != null) {
             kuduReader.close();
+            kuduReader = null;
         }
     }
 


### PR DESCRIPTION
Fix the problem "Caused by: java.lang.IllegalStateException: Cannot proceed, the client has already been closed" when I run in flink local mode.

```
Exception in thread "main" org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
	at org.apache.flink.runtime.jobmaster.JobResult.toJobExecutionResult(JobResult.java:146)
	at org.apache.flink.runtime.minicluster.MiniCluster.executeJobBlocking(MiniCluster.java:626)
	at org.apache.flink.streaming.api.environment.LocalStreamEnvironment.execute(LocalStreamEnvironment.java:117)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:1507)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:1489)
	at org.apache.flink.streaming.api.scala.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.scala:645)
	at com.wj.Temp$.main(Temp.scala:28)
	at com.wj.Temp.main(Temp.scala)
Caused by: java.lang.Exception: java.lang.IllegalStateException: Cannot proceed, the client has already been closed
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.checkThrowSourceExecutionException(SourceStreamTask.java:217)
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask.processInput(SourceStreamTask.java:133)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.run(StreamTask.java:301)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:406)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:705)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:530)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: Cannot proceed, the client has already been closed
	at org.apache.kudu.client.AsyncKuduClient.checkIsClosed(AsyncKuduClient.java:2520)
	at org.apache.kudu.client.AsyncKuduClient.openTableById(AsyncKuduClient.java:840)
	at org.apache.kudu.client.KuduClient.openTableById(KuduClient.java:240)
	at org.apache.kudu.client.KuduScanToken.pbIntoScanner(KuduScanToken.java:193)
	at org.apache.kudu.client.KuduScanToken.deserializeIntoScanner(KuduScanToken.java:118)
	at org.apache.flink.connectors.kudu.connector.reader.KuduReader.scanner(KuduReader.java:82)
	at org.apache.flink.connectors.kudu.batch.KuduInputFormat.open(KuduInputFormat.java:81)
	at org.apache.flink.connectors.kudu.batch.KuduInputFormat.open(KuduInputFormat.java:42)
	at org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction.run(InputFormatSourceFunction.java:85)
	at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:100)
	at org.apache.flink.streaming.api.operators.StreamSource.run(StreamSource.java:63)
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.run(SourceStreamTask.java:203)
```

After closing kuduReader, set it to null to avoid reusing kuduReader in local mode to get the closed kuduClient