### PR TITLE
[hotfix]Fix SetMapper getAdditionalTTL throw NPE

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/row/RowRedisMapper.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/mapper/row/RowRedisMapper.java
@@ -43,7 +43,7 @@ public abstract class RowRedisMapper implements RedisMapper<Tuple2<Boolean, Row>
 
     private RedisCommand redisCommand;
 
-    public int getTtl() {
+    public Integer getTtl() {
         return ttl;
     }
 


### PR DESCRIPTION
ttl is Integer, but `getTtl()` return is int, SET command has not ttl