### PR TITLE
Bump Flink version to 1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jdk:
   - openjdk8
 
 env:
-  - FLINK_VERSION="1.9.0" SCALA_VERSION="2.11"
-  - FLINK_VERSION="1.9.0" SCALA_VERSION="2.11" PROJECT="flink-connector-flume" DOCKER="true"
-  - FLINK_VERSION="1.9.0" SCALA_VERSION="2.12"
-  - FLINK_VERSION="1.9.0" SCALA_VERSION="2.12" PROJECT="flink-connector-flume" DOCKER="true"
+  - FLINK_VERSION="1.10.0" SCALA_VERSION="2.11"
+  - FLINK_VERSION="1.10.0" SCALA_VERSION="2.11" PROJECT="flink-connector-flume" DOCKER="true"
+  - FLINK_VERSION="1.10.0" SCALA_VERSION="2.12"
+  - FLINK_VERSION="1.10.0" SCALA_VERSION="2.12" PROJECT="flink-connector-flume" DOCKER="true"
 
 before_install:
   - ./dev/change-scala-version.sh $SCALA_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <log4j.version>1.2.17</log4j.version>
 
     <!-- Flink version -->
-    <flink.version>1.9.0</flink.version>
+    <flink.version>1.10.0</flink.version>
 
     <junit.jupiter.version>5.4.1</junit.jupiter.version>
     <junit.groups></junit.groups>


### PR DESCRIPTION
Flink 1.10.0 was released over 2 months ago, it is about time to reflect that change here. 🙂 
This is a prerequisite for merging #78.