### PR TITLE
[bahir-232] support Flink Table API & SQL for flink-connector-activemq

### DIFF
--- a/flink-connector-activemq/pom.xml
+++ b/flink-connector-activemq/pom.xml
@@ -112,6 +112,32 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge_2.11</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableFactory.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.flink.formats.json.JsonRowDeserializationSchema;
+import org.apache.flink.formats.json.JsonRowSerializationSchema;
+import org.apache.flink.streaming.connectors.activemq.table.descriptors.AMQValidator;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.StreamTableSinkFactory;
+import org.apache.flink.table.factories.StreamTableSourceFactory;
+import org.apache.flink.table.sinks.StreamTableSink;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.streaming.connectors.activemq.table.descriptors.AMQValidator.*;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.*;
+import static org.apache.flink.table.descriptors.Schema.*;
+
+/**
+ * Factory for creating configured instances of {@link AMQTableSource} or {@link AMQTableSink}.
+ */
+public class AMQTableFactory implements StreamTableSourceFactory<Row>, StreamTableSinkFactory<Row> {
+
+    @Override
+    public StreamTableSink<Row> createStreamTableSink(Map<String, String> properties) {
+        final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+        TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(descriptorProperties.getTableSchema(SCHEMA));
+        String destinationType = descriptorProperties.getString(CONNECTOR_DESTINATION_TYPE);
+        String destinationName = descriptorProperties.getString(CONNECTOR_DESTINATION_NAME);
+        Boolean persistent = descriptorProperties.getOptionalBoolean(CONNECTOR_PERSISTENT).orElse(false);
+        ActiveMQConnectionFactory factory = getActiveMQConnectionFactory(descriptorProperties);
+
+        final AMQSinkConfig<Row> config = new AMQSinkConfig.AMQSinkConfigBuilder<Row>()
+            .setConnectionFactory(factory)
+            .setSerializationSchema(new JsonRowSerializationSchema.Builder(tableSchema.toRowType()).build())
+            .setDestinationName(destinationName)
+            .setDestinationType(DestinationType.valueOf(destinationType.toUpperCase()))
+            .setPersistentDelivery(persistent)
+            .build();
+
+        return new AMQTableSink(config, tableSchema);
+    }
+
+    @Override
+    public StreamTableSource<Row> createStreamTableSource(Map<String, String> properties) {
+        final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+        TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(descriptorProperties.getTableSchema(SCHEMA));
+        String destinationType = descriptorProperties.getString(CONNECTOR_DESTINATION_TYPE);
+        String destinationName = descriptorProperties.getString(CONNECTOR_DESTINATION_NAME);
+        ActiveMQConnectionFactory factory = getActiveMQConnectionFactory(descriptorProperties);
+
+        final AMQSourceConfig<Row> config = new AMQSourceConfig.AMQSourceConfigBuilder<Row>()
+            .setConnectionFactory(factory)
+            .setDeserializationSchema(new JsonRowDeserializationSchema.Builder(tableSchema.toRowType()).build())
+            .setDestinationName(destinationName)
+            .setDestinationType(DestinationType.valueOf(destinationType.toUpperCase()))
+            .build();
+
+        return new AMQTableSource(config, tableSchema);
+    }
+
+    @Override
+    public Map<String, String> requiredContext() {
+        Map<String, String> context = new HashMap<>();
+        context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_AMQ);
+        return context;
+    }
+
+    @Override
+    public List<String> supportedProperties() {
+        List<String> properties = new ArrayList<>();
+
+        properties.add(CONNECTOR_BROKER_URL);
+        properties.add(CONNECTOR_USERNAME);
+        properties.add(CONNECTOR_PASSWORD);
+        properties.add(CONNECTOR_DESTINATION_TYPE);
+        properties.add(CONNECTOR_DESTINATION_NAME);
+        properties.add(CONNECTOR_PERSISTENT);
+
+        // schema
+        properties.add(SCHEMA + ".#." + SCHEMA_DATA_TYPE);
+        properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
+        properties.add(SCHEMA + ".#." + SCHEMA_NAME);
+
+        // computed column
+        properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+
+        // watermark
+        properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
+        properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
+        properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+
+        return properties;
+    }
+
+    private DescriptorProperties getValidatedProperties(Map<String, String> properties) {
+        final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+        descriptorProperties.putProperties(properties);
+        new AMQValidator().validate(descriptorProperties);
+        return descriptorProperties;
+    }
+
+    private ActiveMQConnectionFactory getActiveMQConnectionFactory(DescriptorProperties descriptorProperties){
+        String brokerURL = descriptorProperties.getString(CONNECTOR_BROKER_URL);
+        String username = descriptorProperties.getOptionalString(CONNECTOR_USERNAME).orElse(null);
+        String password = descriptorProperties.getOptionalString(CONNECTOR_PASSWORD).orElse(null);
+        return new ActiveMQConnectionFactory(username, password, brokerURL);
+    }
+}

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableSink.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableSink.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sinks.AppendStreamTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+
+import java.util.Arrays;
+
+/**
+ * An append {@link AppendStreamTableSink} for Apache ActiveMQ
+ */
+public class AMQTableSink implements AppendStreamTableSink<Row> {
+
+    private final AMQSinkConfig<Row> config;
+    private final TableSchema schema;
+
+    /**
+     * The ActiveMQ configuration and the schema of TableSink
+     *
+     * @param config        ActiveMQ configuration
+     * @param schema        the table schema
+     */
+    public AMQTableSink(AMQSinkConfig config, TableSchema schema){
+        this.config = config;
+        this.schema = schema;
+    }
+
+    @Override
+    public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
+        return dataStream.addSink(new AMQSink<>(config));
+    }
+
+    @Override
+    public void emitDataStream(DataStream<Row> dataStream) {
+        consumeDataStream(dataStream);
+    }
+
+    @Override
+    public TypeInformation<Row> getOutputType() {
+        return schema.toRowType();
+    }
+
+    @Override
+    public String[] getFieldNames() {
+        return schema.getFieldNames();
+    }
+
+    @Override
+    public TypeInformation<?>[] getFieldTypes() {
+        return schema.getFieldTypes();
+    }
+
+    @Override
+    public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] typeInformations) {
+        if(!Arrays.equals(getFieldNames(), fieldNames) || !Arrays.equals(getFieldTypes(), typeInformations)) {
+            throw new IllegalArgumentException("Reconfiguration with different fields is not allowed. " +
+                    "Expected: " + Arrays.toString(getFieldNames()) + " / " + Arrays.toString(getFieldTypes()) + ". " +
+                    "But was: " + Arrays.toString(fieldNames) + " / " + Arrays.toString(typeInformations));
+        }
+        return this;
+    }
+}

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableSource.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/AMQTableSource.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.types.Row;
+
+/**
+ * Creates a TableSource to connect an ActiveMQ Queue or Topic
+ *
+ * <p> The AMQTableSource is used as shown in the example below
+ *
+ * <pre>
+ * {@code
+ * AMQSourceConfig<Row> conf = ...
+ * String[] fields = new String[]{"f1","f2"};
+ * DataType[] types = new DataType[]{DataTypes.STRING(), DataTypes.BIGINT()};
+ * TableSchema schema = TableSchema.builder().fields(fields,types).build();
+ * AMQTableSource ats = new AMQTableSource(conf, schema);
+ *
+ * tableEnv.registerTableSource("amqTable", ats);
+ * Table res = tableEnv.sqlQuery("select f1 from amqTable");
+ * }
+ * </pre>
+ */
+public class AMQTableSource implements StreamTableSource<Row> {
+    private final TableSchema schema;
+    private final AMQSourceConfig<Row> config;
+
+    /**
+     * The ActiveMQ configuration and the schema of TableSource
+     *
+     * @param config        ActiveMQ configuration
+     * @param schema        the table schema
+     */
+    public AMQTableSource(AMQSourceConfig<Row> config, TableSchema schema){
+        this.config = config;
+        this.schema = schema;
+    }
+
+
+    @Override
+    public TypeInformation<Row> getReturnType() {
+        return schema.toRowType();
+    }
+
+    @Override
+    public TableSchema getTableSchema() {
+        return schema;
+    }
+
+
+    @Override
+    public DataStream<Row> getDataStream(StreamExecutionEnvironment env) {
+        return env.addSource(new AMQSource<>(config));
+    }
+
+}

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/table/descriptors/AMQ.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/table/descriptors/AMQ.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq.table.descriptors;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import java.util.Map;
+
+import static org.apache.flink.streaming.connectors.activemq.table.descriptors.AMQValidator.*;
+
+/**
+ * Connector descriptor for Apache ActiveMQ
+ */
+public class AMQ extends ConnectorDescriptor {
+    private DescriptorProperties properties = new DescriptorProperties();
+
+    public AMQ() {
+        super(CONNECTOR_TYPE_VALUE_AMQ, 1, true);
+    }
+
+    /**
+     * Sets the <a href="http://activemq.apache.org/configuring-transports.html"> connection
+     * URL</a> used to connect to the ActiveMQ broker.
+     *
+     * @param brokerUrl URL used to connect to the ActiveMQ broker.
+     */
+    public AMQ brokerURL(String brokerUrl) {
+        properties.putString(CONNECTOR_BROKER_URL, brokerUrl);
+        return this;
+    }
+
+    /**
+     * Sets the username used to connect to the ActiveMQ broker.
+     *
+     * @param username username used to connect to the ActiveMQ broker.
+     */
+    public AMQ username(String username) {
+        properties.putString(CONNECTOR_USERNAME, username);
+        return this;
+    }
+
+    /**
+     * Sets the password used to connect to the ActiveMQ broker.
+     *
+     * @param password password used to connect to the ActiveMQ broker.
+     */
+    public AMQ password(String password) {
+        properties.putString(CONNECTOR_PASSWORD, password);
+        return this;
+    }
+
+    @Override
+    protected Map<String, String> toConnectorProperties() {
+        return properties.asMap();
+    }
+}

--- a/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/table/descriptors/AMQValidator.java
+++ b/flink-connector-activemq/src/main/java/org/apache/flink/streaming/connectors/activemq/table/descriptors/AMQValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq.table.descriptors;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import java.util.Arrays;
+
+
+/**
+ * The validator for ActiveMQ
+ */
+public class AMQValidator extends ConnectorDescriptorValidator {
+    public static final String CONNECTOR_TYPE_VALUE_AMQ = "activemq";
+    public static final String CONNECTOR_BROKER_URL = "connector.broker-url";
+    public static final String CONNECTOR_USERNAME = "connector.username";
+    public static final String CONNECTOR_PASSWORD = "connector.password";
+    public static final String CONNECTOR_DESTINATION_TYPE = "connector.destination-type";
+    public static final String CONNECTOR_DESTINATION_NAME = "connector.destination-name";
+    public static final String CONNECTOR_PERSISTENT = "connector.persistent";
+
+    @Override
+    public void validate(DescriptorProperties properties) {
+        super.validate(properties);
+        properties.validateValue(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_AMQ, false);
+        properties.validateString(CONNECTOR_BROKER_URL, false, 1);
+        properties.validateString(CONNECTOR_USERNAME, true, 0);
+        properties.validateString(CONNECTOR_PASSWORD, true, 0);
+        properties.validateEnumValues(CONNECTOR_DESTINATION_TYPE, false,
+            Arrays.asList("QUEUE", "TOPIC"));
+        properties.validateString(CONNECTOR_DESTINATION_NAME, false, 1);
+        validateSinkProperties(properties);
+    }
+
+    private void validateSinkProperties(DescriptorProperties properties) {
+        properties.validateBoolean(CONNECTOR_PERSISTENT, true);
+    }
+
+}

--- a/flink-connector-activemq/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connector-activemq/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.streaming.connectors.activemq.AMQTableFactory

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQTableFactoryTest.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/AMQTableFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.types.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class AMQTableFactoryTest {
+
+    private static final TableSchema SCHEMA = TableSchema.builder()
+            .field("id", DataTypes.INT())
+            .field("title", DataTypes.STRING())
+            .field("author", DataTypes.STRING())
+            .field("price", DataTypes.DOUBLE())
+            .field("qty", DataTypes.INT()).build();
+
+    private static final String SCHEMA_STRING = "root\n" +
+            " |-- id: INT\n" +
+            " |-- title: STRING\n" +
+            " |-- author: STRING\n" +
+            " |-- price: DOUBLE\n" +
+            " |-- qty: INT\n";
+
+    private DescriptorProperties createDescriptor(TableSchema schema){
+        HashMap<String, String> tableProps = new HashMap<>();
+        tableProps.put("connector.type","activemq");
+        tableProps.put("connector.broker-url","vm://localhost?broker.persistent=false");
+        tableProps.put("connector.destination-type", "QUEUE");
+        tableProps.put("connector.destination-name", "queue_name");
+        DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+        descriptorProperties.putTableSchema("schema", schema);
+        descriptorProperties.putProperties(tableProps);
+        return descriptorProperties;
+    }
+
+    @Test
+    public void testTableSourceFactory(){
+        DescriptorProperties descriptor = createDescriptor(SCHEMA);
+        TableSource<Row> source = TableFactoryService.find(AMQTableFactory.class, descriptor.asMap())
+                .createTableSource(descriptor.asMap());
+        TableSchema tableSchema = source.getTableSchema();
+
+        Assert.assertTrue(source instanceof AMQTableSource);
+        Assert.assertEquals(5, tableSchema.getFieldCount());
+        Assert.assertEquals(SCHEMA_STRING, tableSchema.toString());
+    }
+
+    @Test
+    public void testTableSinkFactory() {
+        DescriptorProperties descriptor = createDescriptor(SCHEMA);
+        TableSink<Row> sink = TableFactoryService.find(AMQTableFactory.class, descriptor.asMap())
+                .createTableSink(descriptor.asMap());
+        TableSchema tableSchema = sink.getTableSchema();
+
+        Assert.assertTrue(sink instanceof AMQTableSink);
+        Assert.assertEquals(5, tableSchema.getFieldCount());
+        Assert.assertEquals(SCHEMA_STRING, tableSchema.toString());
+    }
+}

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQConnectorITCase.java
@@ -47,7 +47,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Random;
 
-import static org.apache.flink.test.util.TestUtils.tryExecute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;

--- a/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQTableITCase.java
+++ b/flink-connector-activemq/src/test/java/org/apache/flink/streaming/connectors/activemq/ActiveMQTableITCase.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.activemq;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.test.util.SuccessException;
+import org.apache.flink.types.Row;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ActiveMQTableITCase {
+    private static final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    private static final EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+    private static final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, bsSettings);
+
+    private static final String TABLE_CREATE_SQL = "CREATE TABLE books (" +
+            " id int, " +
+            " title varchar, " +
+            " author varchar, " +
+            " price double, " +
+            " qty int " +
+            ") with (" +
+            " 'connector.type' = 'activemq', " +
+            " 'connector.broker-url' = 'vm://localhost?broker.persistent=false', " +
+            " 'connector.destination-type' = 'QUEUE', " +
+            " 'connector.destination-name' = 'source_queue' " +
+            ")";
+
+    private static final String INITIALIZE_TABLE_SQL = "INSERT INTO books VALUES\n" +
+            "(1001, 'Java public for dummies', 'Tan Ah Teck', 11.11, 11),\n" +
+            "(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),\n" +
+            "(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),\n" +
+            "(1004, 'A Cup of Java', 'Kumar', 44.44, 44),\n" +
+            "(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55),\n" +
+            "(1006, 'A Teaspoon of Java 1.4', 'Kevin Jones', 66.66, 66),\n" +
+            "(1007, 'A Teaspoon of Java 1.5', 'Kevin Jones', 77.77, 77),\n" +
+            "(1008, 'A Teaspoon of Java 1.6', 'Kevin Jones', 88.88, 88),\n" +
+            "(1009, 'A Teaspoon of Java 1.7', 'Kevin Jones', 99.99, 99),\n" +
+            "(1010, 'A Teaspoon of Java 1.8', 'Kevin Jones', 33.33, 100)";
+
+    private static final String QUERY_TABLE_SQL = "SELECT * FROM books";
+
+
+    @Test
+    public void testActiveMQSourceSink() throws Exception{
+
+        // create activemq source table
+        tEnv.sqlUpdate(TABLE_CREATE_SQL);
+
+        // produce event to activemq
+        tEnv.sqlUpdate(INITIALIZE_TABLE_SQL);
+
+        // consume from activemq
+        Table table = tEnv.sqlQuery(QUERY_TABLE_SQL);
+        DataStream<Row> result = tEnv.toAppendStream(table, Row.class);
+        result.addSink(new TestingSinkFunction(10)).setParallelism(1);
+
+        try {
+            env.execute("AMQTest");
+        } catch (Throwable e) {
+            // we have to use a specific exception to indicate the job is finished,
+            // because the activemq source is infinite.
+            if (!isCausedByJobFinished(e)) {
+                // re-throw
+                throw e;
+            }
+        }
+
+        List<String> expected = Arrays.asList(
+                "1001,Java public for dummies,Tan Ah Teck,11.11,11",
+                "1002,More Java for dummies,Tan Ah Teck,22.22,22",
+                "1003,More Java for more dummies,Mohammad Ali,33.33,33",
+                "1004,A Cup of Java,Kumar,44.44,44",
+                "1005,A Teaspoon of Java,Kevin Jones,55.55,55",
+                "1006,A Teaspoon of Java 1.4,Kevin Jones,66.66,66",
+                "1007,A Teaspoon of Java 1.5,Kevin Jones,77.77,77",
+                "1008,A Teaspoon of Java 1.6,Kevin Jones,88.88,88",
+                "1009,A Teaspoon of Java 1.7,Kevin Jones,99.99,99",
+                "1010,A Teaspoon of Java 1.8,Kevin Jones,33.33,100"
+        );
+
+        Assert.assertEquals(expected, TestingSinkFunction.rows);
+    }
+
+    private static final class TestingSinkFunction implements SinkFunction<Row> {
+
+        private static final long serialVersionUID = 455430015321124493L;
+        private static List<String> rows = new ArrayList<>();
+
+        private final int expectedSize;
+
+        private TestingSinkFunction(int expectedSize) {
+            this.expectedSize = expectedSize;
+            rows.clear();
+        }
+
+        @Override
+        public void invoke(Row value, Context context) throws Exception {
+            rows.add(value.toString());
+            if (rows.size() >= expectedSize) {
+                Collections.sort(TestingSinkFunction.rows);
+                // job finish
+                throw new SuccessException();
+            }
+        }
+    }
+
+    private static boolean isCausedByJobFinished(Throwable e) {
+        if (e instanceof SuccessException) {
+            return true;
+        } else if (e.getCause() != null) {
+            return isCausedByJobFinished(e.getCause());
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
flink-connector-activemq does not support Flink Table API & SQL, based on the the existing code, it is not very difficult to support this feature, we just need to implement 4 classes:   AMQTableSource、AMQTableSink、AMQTableSourceFactory and AMQTableSourceFactory. Then we can connect activemq by the following way:

`String TABLE_CREATE_SQL = "CREATE TABLE books (" +
        " id int, " +
        " title varchar, " +
        " author varchar, " +
        " price double, " +
        " qty int " +
        ") with (" +
        " 'connector.type' = 'activemq', " +
        " 'connector.broker-url' = 'vm://localhost?broker.persistent=false', " +
        " 'connector.destination-type' = 'QUEUE', " +
        " 'connector.destination-name' = 'source_queue' " +
        ")";

String INITIALIZE_TABLE_SQL = "INSERT INTO books VALUES\n" +
        "(1001, 'Java public for dummies', 'Tan Ah Teck', 11.11, 11),\n" +
        "(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),\n" +
        "(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),\n" +
        "(1004, 'A Cup of Java', 'Kumar', 44.44, 44),\n" +
        "(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55),\n" +
        "(1006, 'A Teaspoon of Java 1.4', 'Kevin Jones', 66.66, 66),\n" +
        "(1007, 'A Teaspoon of Java 1.5', 'Kevin Jones', 77.77, 77),\n" +
        "(1008, 'A Teaspoon of Java 1.6', 'Kevin Jones', 88.88, 88),\n" +
        "(1009, 'A Teaspoon of Java 1.7', 'Kevin Jones', 99.99, 99),\n" +
        "(1010, 'A Teaspoon of Java 1.8', 'Kevin Jones', 33.33, 100)";

String QUERY_TABLE_SQL = "SELECT * FROM books";

// create activemq source table
tEnv.sqlUpdate(TABLE_CREATE_SQL);

// produce event to activemq
tEnv.sqlUpdate(INITIALIZE_TABLE_SQL);

// consume from activemq
Table table = tEnv.sqlQuery(QUERY_TABLE_SQL);`