### PR TITLE
[BAHIR-247] Provide connection validation/idle testing for Flink-Redis Connector

### DIFF
--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisClusterConfig.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisClusterConfig.java
@@ -48,12 +48,15 @@ public class FlinkJedisClusterConfig extends FlinkJedisConfigBase {
      * @param maxIdle the cap on the number of "idle" instances in the pool
      * @param minIdle the minimum number of idle objects to maintain in the pool
      * @param password the password of redis cluster
+     * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned, default value is false
+     * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool, default value is false
+     * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor, default value is false
      * @throws NullPointerException if parameter {@code nodes} is {@code null}
      */
     private FlinkJedisClusterConfig(Set<InetSocketAddress> nodes, int connectionTimeout, int maxRedirections,
                                     int maxTotal, int maxIdle, int minIdle,
-                                    String password) {
-        super(connectionTimeout, maxTotal, maxIdle, minIdle, password);
+                                    String password, boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
+        super(connectionTimeout, maxTotal, maxIdle, minIdle, password, testOnBorrow, testOnReturn, testWhileIdle);
 
         Objects.requireNonNull(nodes, "Node information should be presented");
         Util.checkArgument(!nodes.isEmpty(), "Redis cluster hosts should not be empty");
@@ -96,6 +99,9 @@ public class FlinkJedisClusterConfig extends FlinkJedisConfigBase {
         private int maxTotal = GenericObjectPoolConfig.DEFAULT_MAX_TOTAL;
         private int maxIdle = GenericObjectPoolConfig.DEFAULT_MAX_IDLE;
         private int minIdle = GenericObjectPoolConfig.DEFAULT_MIN_IDLE;
+        private boolean testOnBorrow = GenericObjectPoolConfig.DEFAULT_TEST_ON_BORROW;
+        private boolean testOnReturn = GenericObjectPoolConfig.DEFAULT_TEST_ON_RETURN;
+        private boolean testWhileIdle = GenericObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE;
         private String password;
 
         /**
@@ -180,18 +186,58 @@ public class FlinkJedisClusterConfig extends FlinkJedisConfigBase {
         }
 
         /**
+         * Sets value for the {@code testOnBorrow} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned
+         * @return Builder itself
+         */
+        public Builder setTestOnBorrow(boolean testOnBorrow) {
+            this.testOnBorrow = testOnBorrow;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testOnReturn} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool
+         * @return Builder itself
+         */
+        public Builder setTestOnReturn(boolean testOnReturn) {
+            this.testOnReturn = testOnReturn;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testWhileIdle} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * Setting this to true will also set default idle-testing parameters provided in Jedis
+         * @see redis.clients.jedis.JedisPoolConfig
+         *
+         * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor
+         * @return Builder itself
+         */
+        public Builder setTestWhileIdle(boolean testWhileIdle) {
+            this.testWhileIdle = testWhileIdle;
+            return this;
+        }
+
+        /**
          * Builds JedisClusterConfig.
          *
          * @return JedisClusterConfig
          */
         public FlinkJedisClusterConfig build() {
-            return new FlinkJedisClusterConfig(nodes, timeout, maxRedirections, maxTotal, maxIdle, minIdle, password);
+            return new FlinkJedisClusterConfig(nodes, timeout, maxRedirections, maxTotal, maxIdle, minIdle, password, testOnBorrow, testOnReturn, testWhileIdle);
         }
     }
 
     @Override
     public String toString() {
         return "FlinkJedisClusterConfig{" +
+<<<<<<< master
             "nodes=" + nodes +
             ", timeout=" + connectionTimeout +
             ", maxRedirections=" + maxRedirections +
@@ -199,5 +245,18 @@ public class FlinkJedisClusterConfig extends FlinkJedisConfigBase {
             ", maxIdle=" + maxIdle +
             ", minIdle=" + minIdle +
             '}';
+=======
+          "nodes=" + nodes +
+          ", maxRedirections=" + maxRedirections +
+          ", maxTotal=" + maxTotal +
+          ", maxIdle=" + maxIdle +
+          ", minIdle=" + minIdle +
+          ", connectionTimeout=" + connectionTimeout +
+          ", password='" + password + '\'' +
+          ", testOnBorrow=" + testOnBorrow +
+          ", testOnReturn=" + testOnReturn +
+          ", testWhileIdle=" + testWhileIdle +
+          '}';
+>>>>>>> [BAHIR-247] Provide connection validation/idle testing for Flink-Redis Connector
     }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisConfigBase.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisConfigBase.java
@@ -33,7 +33,11 @@ public abstract class FlinkJedisConfigBase implements Serializable {
     protected final int connectionTimeout;
     protected final String password;
 
-    protected FlinkJedisConfigBase(int connectionTimeout, int maxTotal, int maxIdle, int minIdle, String password) {
+    protected final boolean testOnBorrow;
+    protected final boolean testOnReturn;
+    protected final boolean testWhileIdle;
+
+    protected FlinkJedisConfigBase(int connectionTimeout, int maxTotal, int maxIdle, int minIdle, String password, boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
         Util.checkArgument(connectionTimeout >= 0, "connection timeout can not be negative");
         Util.checkArgument(maxTotal >= 0, "maxTotal value can not be negative");
         Util.checkArgument(maxIdle >= 0, "maxIdle value can not be negative");
@@ -44,6 +48,9 @@ public abstract class FlinkJedisConfigBase implements Serializable {
         this.maxIdle = maxIdle;
         this.minIdle = minIdle;
         this.password = password;
+        this.testOnBorrow = testOnBorrow;
+        this.testOnReturn = testOnReturn;
+        this.testWhileIdle = testWhileIdle;
     }
 
     /**
@@ -98,5 +105,41 @@ public abstract class FlinkJedisConfigBase implements Serializable {
      */
     public String getPassword() {
         return password;
+    }
+
+    /**
+     * Get the value for the {@code testOnBorrow} configuration attribute
+     * for pools to be created with this configuration instance.
+     *
+     * @return  The current setting of {@code testOnBorrow} for this
+     *          configuration instance
+     * @see GenericObjectPoolConfig#getTestOnBorrow()
+     */
+    public boolean getTestOnBorrow() {
+        return testOnBorrow;
+    }
+
+    /**
+     * Get the value for the {@code testOnReturn} configuration attribute
+     * for pools to be created with this configuration instance.
+     *
+     * @return  The current setting of {@code testOnReturn} for this
+     *          configuration instance
+     * @see GenericObjectPoolConfig#getTestOnReturn()
+     */
+    public boolean getTestOnReturn() {
+        return testOnReturn;
+    }
+
+    /**
+     * Get the value for the {@code testWhileIdle} configuration attribute
+     * for pools to be created with this configuration instance.
+     *
+     * @return  The current setting of {@code testWhileIdle} for this
+     *          configuration instance
+     * @see GenericObjectPoolConfig#getTestWhileIdle()
+     */
+    public boolean getTestWhileIdle() {
+        return testWhileIdle;
     }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisPoolConfig.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisPoolConfig.java
@@ -45,11 +45,15 @@ public class FlinkJedisPoolConfig extends FlinkJedisConfigBase {
      * @param maxTotal the maximum number of objects that can be allocated by the pool, default value is 8
      * @param maxIdle the cap on the number of "idle" instances in the pool, default value is 8
      * @param minIdle the minimum number of idle objects to maintain in the pool, default value is 0
+     * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned, default value is false
+     * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool, default value is false
+     * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor, default value is false
      * @throws NullPointerException if parameter {@code host} is {@code null}
      */
     private FlinkJedisPoolConfig(String host, int port, int connectionTimeout, String password, int database,
-                                int maxTotal, int maxIdle, int minIdle) {
-        super(connectionTimeout, maxTotal, maxIdle, minIdle, password);
+                                 int maxTotal, int maxIdle, int minIdle,
+                                 boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
+        super(connectionTimeout, maxTotal, maxIdle, minIdle, password, testOnBorrow, testOnReturn, testWhileIdle);
         Objects.requireNonNull(host, "Host information should be presented");
         this.host = host;
         this.port = port;
@@ -96,6 +100,9 @@ public class FlinkJedisPoolConfig extends FlinkJedisConfigBase {
         private int maxTotal = GenericObjectPoolConfig.DEFAULT_MAX_TOTAL;
         private int maxIdle = GenericObjectPoolConfig.DEFAULT_MAX_IDLE;
         private int minIdle = GenericObjectPoolConfig.DEFAULT_MIN_IDLE;
+        private boolean testOnBorrow = GenericObjectPoolConfig.DEFAULT_TEST_ON_BORROW;
+        private boolean testOnReturn = GenericObjectPoolConfig.DEFAULT_TEST_ON_RETURN;
+        private boolean testWhileIdle = GenericObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE;
 
         /**
          * Sets value for the {@code maxTotal} configuration attribute
@@ -188,6 +195,44 @@ public class FlinkJedisPoolConfig extends FlinkJedisConfigBase {
             return this;
         }
 
+        /**
+         * Sets value for the {@code testOnBorrow} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned
+         * @return Builder itself
+         */
+        public Builder setTestOnBorrow(boolean testOnBorrow) {
+            this.testOnBorrow = testOnBorrow;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testOnReturn} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool
+         * @return Builder itself
+         */
+        public Builder setTestOnReturn(boolean testOnReturn) {
+            this.testOnReturn = testOnReturn;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testWhileIdle} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * Setting this to true will also set default idle-testing parameters provided in Jedis
+         * @see redis.clients.jedis.JedisPoolConfig
+         *
+         * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor
+         * @return Builder itself
+         */
+        public Builder setTestWhileIdle(boolean testWhileIdle) {
+            this.testWhileIdle = testWhileIdle;
+            return this;
+        }
 
         /**
          * Builds JedisPoolConfig.
@@ -195,13 +240,14 @@ public class FlinkJedisPoolConfig extends FlinkJedisConfigBase {
          * @return JedisPoolConfig
          */
         public FlinkJedisPoolConfig build() {
-            return new FlinkJedisPoolConfig(host, port, timeout, password, database, maxTotal, maxIdle, minIdle);
+            return new FlinkJedisPoolConfig(host, port, timeout, password, database, maxTotal, maxIdle, minIdle, testOnBorrow, testOnReturn, testWhileIdle);
         }
     }
 
     @Override
     public String toString() {
         return "FlinkJedisPoolConfig{" +
+<<<<<<< master
             "host='" + host + '\'' +
             ", port=" + port +
             ", timeout=" + connectionTimeout +
@@ -210,5 +256,19 @@ public class FlinkJedisPoolConfig extends FlinkJedisConfigBase {
             ", maxIdle=" + maxIdle +
             ", minIdle=" + minIdle +
             '}';
+=======
+          "host='" + host + '\'' +
+          ", port=" + port +
+          ", database=" + database +
+          ", maxTotal=" + maxTotal +
+          ", maxIdle=" + maxIdle +
+          ", minIdle=" + minIdle +
+          ", connectionTimeout=" + connectionTimeout +
+          ", password='" + password + '\'' +
+          ", testOnBorrow=" + testOnBorrow +
+          ", testOnReturn=" + testOnReturn +
+          ", testWhileIdle=" + testWhileIdle +
+          '}';
+>>>>>>> [BAHIR-247] Provide connection validation/idle testing for Flink-Redis Connector
     }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisSentinelConfig.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisSentinelConfig.java
@@ -52,15 +52,18 @@ public class FlinkJedisSentinelConfig extends FlinkJedisConfigBase {
      * @param maxTotal maxTotal the maximum number of objects that can be allocated by the pool
      * @param maxIdle the cap on the number of "idle" instances in the pool
      * @param minIdle the minimum number of idle objects to maintain in the pool
-     *
+     * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned, default value is false
+     * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool, default value is false
+     * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor, default value is false
      * @throws NullPointerException if {@code masterName} or {@code sentinels} is {@code null}
      * @throws IllegalArgumentException if {@code sentinels} are empty
      */
     private FlinkJedisSentinelConfig(String masterName, Set<String> sentinels,
-                                    int connectionTimeout, int soTimeout,
-                                    String password, int database,
-                                    int maxTotal, int maxIdle, int minIdle) {
-        super(connectionTimeout, maxTotal, maxIdle, minIdle, password);
+                                     int connectionTimeout, int soTimeout,
+                                     String password, int database,
+                                     int maxTotal, int maxIdle, int minIdle,
+                                     boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
+        super(connectionTimeout, maxTotal, maxIdle, minIdle, password, testOnBorrow, testOnReturn, testWhileIdle);
         Objects.requireNonNull(masterName, "Master name should be presented");
         Objects.requireNonNull(sentinels, "Sentinels information should be presented");
         Util.checkArgument(!sentinels.isEmpty(), "Sentinel hosts should not be empty");
@@ -120,6 +123,9 @@ public class FlinkJedisSentinelConfig extends FlinkJedisConfigBase {
         private int maxTotal = GenericObjectPoolConfig.DEFAULT_MAX_TOTAL;
         private int maxIdle = GenericObjectPoolConfig.DEFAULT_MAX_IDLE;
         private int minIdle = GenericObjectPoolConfig.DEFAULT_MIN_IDLE;
+        private boolean testOnBorrow = GenericObjectPoolConfig.DEFAULT_TEST_ON_BORROW;
+        private boolean testOnReturn = GenericObjectPoolConfig.DEFAULT_TEST_ON_RETURN;
+        private boolean testWhileIdle = GenericObjectPoolConfig.DEFAULT_TEST_WHILE_IDLE;
 
         /**
          * Sets master name of the replica set.
@@ -224,19 +230,59 @@ public class FlinkJedisSentinelConfig extends FlinkJedisConfigBase {
         }
 
         /**
+         * Sets value for the {@code testOnBorrow} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnBorrow Whether objects borrowed from the pool will be validated before being returned
+         * @return Builder itself
+         */
+        public Builder setTestOnBorrow(boolean testOnBorrow) {
+            this.testOnBorrow = testOnBorrow;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testOnReturn} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * @param testOnReturn Whether objects borrowed from the pool will be validated when they are returned to the pool
+         * @return Builder itself
+         */
+        public Builder setTestOnReturn(boolean testOnReturn) {
+            this.testOnReturn = testOnReturn;
+            return this;
+        }
+
+        /**
+         * Sets value for the {@code testWhileIdle} configuration attribute
+         * for pools to be created with this configuration instance.
+         *
+         * Setting this to true will also set default idle-testing parameters provided in Jedis
+         * @see redis.clients.jedis.JedisPoolConfig
+         *
+         * @param testWhileIdle Whether objects sitting idle in the pool will be validated by the idle object evictor
+         * @return Builder itself
+         */
+        public Builder setTestWhileIdle(boolean testWhileIdle) {
+            this.testWhileIdle = testWhileIdle;
+            return this;
+        }
+
+        /**
          * Builds JedisSentinelConfig.
          *
          * @return JedisSentinelConfig
          */
         public FlinkJedisSentinelConfig build(){
             return new FlinkJedisSentinelConfig(masterName, sentinels, connectionTimeout, soTimeout,
-                password, database, maxTotal, maxIdle, minIdle);
+              password, database, maxTotal, maxIdle, minIdle, testOnBorrow, testOnReturn, testWhileIdle);
         }
     }
 
     @Override
     public String toString() {
         return "FlinkJedisSentinelConfig{" +
+<<<<<<< master
             "masterName='" + masterName + '\'' +
             ", connectionTimeout=" + connectionTimeout +
             ", soTimeout=" + soTimeout +
@@ -245,5 +291,20 @@ public class FlinkJedisSentinelConfig extends FlinkJedisConfigBase {
             ", maxIdle=" + maxIdle +
             ", minIdle=" + minIdle +
             '}';
+=======
+          "masterName='" + masterName + '\'' +
+          ", sentinels=" + sentinels +
+          ", soTimeout=" + soTimeout +
+          ", database=" + database +
+          ", maxTotal=" + maxTotal +
+          ", maxIdle=" + maxIdle +
+          ", minIdle=" + minIdle +
+          ", connectionTimeout=" + connectionTimeout +
+          ", password='" + password + '\'' +
+          ", testOnBorrow=" + testOnBorrow +
+          ", testOnReturn=" + testOnReturn +
+          ", testWhileIdle=" + testWhileIdle +
+          '}';
+>>>>>>> [BAHIR-247] Provide connection validation/idle testing for Flink-Redis Connector
     }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainerBuilder.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainerBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisPoolC
 import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisSentinelConfig;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.JedisSentinelPool;
 
 import java.util.Objects;
@@ -64,9 +65,17 @@ public class RedisCommandsContainerBuilder {
 
         GenericObjectPoolConfig genericObjectPoolConfig = getGenericObjectPoolConfig(jedisPoolConfig);
 
+        if (jedisPoolConfig.getTestWhileIdle()) {
+            // default parameters from redis.clients.jedis.JedisPoolConfig
+            genericObjectPoolConfig.setTestWhileIdle(true);
+            genericObjectPoolConfig.setMinEvictableIdleTimeMillis(60000);
+            genericObjectPoolConfig.setTimeBetweenEvictionRunsMillis(30000);
+            genericObjectPoolConfig.setNumTestsPerEvictionRun(-1);
+        }
+
         JedisPool jedisPool = new JedisPool(genericObjectPoolConfig, jedisPoolConfig.getHost(),
-            jedisPoolConfig.getPort(), jedisPoolConfig.getConnectionTimeout(), jedisPoolConfig.getPassword(),
-            jedisPoolConfig.getDatabase());
+          jedisPoolConfig.getPort(), jedisPoolConfig.getConnectionTimeout(), jedisPoolConfig.getPassword(),
+          jedisPoolConfig.getDatabase());
         return new RedisContainer(jedisPool);
     }
 
@@ -82,12 +91,20 @@ public class RedisCommandsContainerBuilder {
 
         GenericObjectPoolConfig genericObjectPoolConfig = getGenericObjectPoolConfig(jedisClusterConfig);
 
+        if (jedisClusterConfig.getTestWhileIdle()) {
+            // default parameters from redis.clients.jedis.JedisPoolConfig
+            genericObjectPoolConfig.setTestWhileIdle(true);
+            genericObjectPoolConfig.setMinEvictableIdleTimeMillis(60000);
+            genericObjectPoolConfig.setTimeBetweenEvictionRunsMillis(30000);
+            genericObjectPoolConfig.setNumTestsPerEvictionRun(-1);
+        }
+
         JedisCluster jedisCluster = new JedisCluster(jedisClusterConfig.getNodes(),
-                jedisClusterConfig.getConnectionTimeout(),
-                jedisClusterConfig.getConnectionTimeout(),
-                jedisClusterConfig.getMaxRedirections(),
-                jedisClusterConfig.getPassword(),
-                genericObjectPoolConfig);
+          jedisClusterConfig.getConnectionTimeout(),
+          jedisClusterConfig.getConnectionTimeout(),
+          jedisClusterConfig.getMaxRedirections(),
+          jedisClusterConfig.getPassword(),
+          genericObjectPoolConfig);
         return new RedisClusterContainer(jedisCluster);
     }
 
@@ -103,10 +120,18 @@ public class RedisCommandsContainerBuilder {
 
         GenericObjectPoolConfig genericObjectPoolConfig = getGenericObjectPoolConfig(jedisSentinelConfig);
 
+        if (jedisSentinelConfig.getTestWhileIdle()) {
+            // default parameters from redis.clients.jedis.JedisPoolConfig
+            genericObjectPoolConfig.setTestWhileIdle(true);
+            genericObjectPoolConfig.setMinEvictableIdleTimeMillis(60000);
+            genericObjectPoolConfig.setTimeBetweenEvictionRunsMillis(30000);
+            genericObjectPoolConfig.setNumTestsPerEvictionRun(-1);
+        }
+
         JedisSentinelPool jedisSentinelPool = new JedisSentinelPool(jedisSentinelConfig.getMasterName(),
-            jedisSentinelConfig.getSentinels(), genericObjectPoolConfig,
-            jedisSentinelConfig.getConnectionTimeout(), jedisSentinelConfig.getSoTimeout(),
-            jedisSentinelConfig.getPassword(), jedisSentinelConfig.getDatabase());
+          jedisSentinelConfig.getSentinels(), genericObjectPoolConfig,
+          jedisSentinelConfig.getConnectionTimeout(), jedisSentinelConfig.getSoTimeout(),
+          jedisSentinelConfig.getPassword(), jedisSentinelConfig.getDatabase());
         return new RedisContainer(jedisSentinelPool);
     }
 
@@ -115,6 +140,8 @@ public class RedisCommandsContainerBuilder {
         genericObjectPoolConfig.setMaxIdle(jedisConfig.getMaxIdle());
         genericObjectPoolConfig.setMaxTotal(jedisConfig.getMaxTotal());
         genericObjectPoolConfig.setMinIdle(jedisConfig.getMinIdle());
+        genericObjectPoolConfig.setTestOnBorrow(jedisConfig.getTestOnBorrow());
+        genericObjectPoolConfig.setTestOnReturn(jedisConfig.getTestOnReturn());
         return genericObjectPoolConfig;
     }
 }

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainerBuilder.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisCommandsContainerBuilder.java
@@ -23,7 +23,6 @@ import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisPoolC
 import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisSentinelConfig;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.JedisSentinelPool;
 
 import java.util.Objects;

--- a/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisConfigBaseTest.java
+++ b/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/common/config/FlinkJedisConfigBaseTest.java
@@ -23,28 +23,29 @@ public class FlinkJedisConfigBaseTest extends TestLogger {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIllegalArgumentExceptionIfTimeOutIsNegative(){
-        new TestConfig(-1, 0, 0, 0);
+        new TestConfig(-1, 0, 0, 0, false, false, false);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIllegalArgumentExceptionIfMaxTotalIsNegative(){
-        new TestConfig(1, -1, 0, 0);
+        new TestConfig(1, -1, 0, 0, false, false, false);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIllegalArgumentExceptionIfMaxIdleIsNegative(){
-        new TestConfig(0, 0, -1, 0);
+        new TestConfig(0, 0, -1, 0, false, false, false);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIllegalArgumentExceptionIfMinIdleIsNegative(){
-        new TestConfig(0, 0, 0, -1);
+        new TestConfig(0, 0, 0, -1, false, false, false);
     }
 
     private class TestConfig extends FlinkJedisConfigBase {
 
-        protected TestConfig(int connectionTimeout, int maxTotal, int maxIdle, int minIdle) {
-            super(connectionTimeout, maxTotal, maxIdle, minIdle, "dummy");
+        protected TestConfig(int connectionTimeout, int maxTotal, int maxIdle, int minIdle,
+                             boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
+            super(connectionTimeout, maxTotal, maxIdle, minIdle, "dummy", testOnBorrow, testOnReturn, testWhileIdle);
         }
     }
 }


### PR DESCRIPTION
Added `testOnBorrow`, `testOnReturn` and `testWhileIdle` options for Flink-Redis Connector. Details can be found at https://issues.apache.org/jira/browse/BAHIR-247