### PR TITLE
Fix malformed artifactId

### DIFF
--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -28,7 +28,7 @@ under the License.
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-connector-redis_${scala.binary.version}</artifactId>
+    <artifactId>flink-connector-redis_2.11</artifactId>
     <name>flink-connector-redis</name>
 
     <packaging>jar</packaging>


### PR DESCRIPTION
```
> mvn compile
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.bahir:flink-connector-redis_2.11:jar:1.1-SNAPSHOT
[WARNING] 'artifactId' contains an expression but should be a constant. @ org.apache.bahir:flink-connector-redis_${scala.binary.version}:1.1-SNAPSHOT, /Users/chenyisheng/source/yiksanchan/bahir-flink/flink-connector-redis/pom.xml, line 31, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```