### PR TITLE
[hotfix] Fix flume sink and utils test

### DIFF
--- a/flink-connector-flume/pom.xml
+++ b/flink-connector-flume/pom.xml
@@ -36,7 +36,7 @@ under the License.
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
 		<flume-ng.version>1.9.0</flume-ng.version>
-		<testcontainers.version>1.14.3</testcontainers.version>
+		<testcontainers.version>1.15.3</testcontainers.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/FlumeServerTest.java
+++ b/flink-connector-flume/src/test/java/org/apache/flink/streaming/connectors/flume/FlumeServerTest.java
@@ -19,41 +19,42 @@ package org.apache.flink.streaming.connectors.flume;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
+
 
 public class FlumeServerTest {
 
     private static final Integer EXPOSED_PORT = 44444;
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("eskabetxe/flume");
 
-    public GenericContainer<?> sink = new GenericContainer<>("eskabetxe/flume")
-
+    private final GenericContainer<?> sink = new GenericContainer<>(DOCKER_IMAGE_NAME)
             .withCopyFileToContainer(MountableFile.forClasspathResource("docker/conf/sink.conf"), "/opt/flume-config/flume.conf")
             .withEnv("FLUME_AGENT_NAME", "docker");
 
-    public GenericContainer<?> source = new GenericContainer<>("eskabetxe/flume")
+    private final GenericContainer<?> source = new GenericContainer<>(DOCKER_IMAGE_NAME)
             .withCopyFileToContainer(MountableFile.forClasspathResource("docker/conf/source.conf"), "/opt/flume-config/flume.conf")
             .withExposedPorts(EXPOSED_PORT)
             .withEnv("FLUME_AGENT_NAME", "docker")
-            .dependsOn(sink);
+            .dependsOn(this.sink);
 
     @BeforeEach
-    void start() {
-        sink.start();
-        source.start();
+    void init() {
+        this.sink.start();
+        this.source.start();
     }
 
     @AfterEach
-    void stop() {
-        source.stop();
-        sink.stop();
+    void tearDown() {
+        this.source.stop();
+        this.sink.stop();
     }
 
     protected String getHost() {
-        return source.getHost();
+        return this.source.getHost();
     }
 
     protected Integer getPort() {
-        return source.getMappedPort(EXPOSED_PORT);
+        return this.source.getMappedPort(EXPOSED_PORT);
     }
-
 }


### PR DESCRIPTION
Currently, the two tests of the module `flink-conector-flume` are failing. Down here you can see the logs printed after running `mvn test -pl flink-connector-flume` command in my terminal. It seems that `testcontainers` is failing to pull the flume container. To fix the issue I have just updated the `testcontainers` dependency to the newest version (1.15.3).
```console
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.flink.streaming.connectors.flume.FlumeUtilsTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.766 s <<< FAILURE! - in org.apache.flink.streaming.connectors.flume.FlumeUtilsTest
[ERROR] testGetRpcClient  Time elapsed: 0.647 s  <<< ERROR!
org.testcontainers.containers.ContainerLaunchException: Container startup failed
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=eskabetxe/flume:latest, imagePullPolicy=DefaultPullPolicy())
Caused by: com.github.dockerjava.api.exception.NotFoundException: 
{"message":"No such image: testcontainersofficial/ryuk:0.3.0"}


[ERROR] testDestroy  Time elapsed: 0.075 s  <<< ERROR!
org.testcontainers.containers.ContainerLaunchException: Container startup failed
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=eskabetxe/flume:latest, imagePullPolicy=DefaultPullPolicy())
Caused by: com.github.dockerjava.api.exception.NotFoundException: 
{"message":"No such image: testcontainersofficial/ryuk:0.3.0"}


[INFO] Running org.apache.flink.streaming.connectors.flume.FlumeSinkTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.067 s <<< FAILURE! - in org.apache.flink.streaming.connectors.flume.FlumeSinkTest
[ERROR] testSink  Time elapsed: 0.067 s  <<< ERROR!
org.testcontainers.containers.ContainerLaunchException: Container startup failed
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=eskabetxe/flume:latest, imagePullPolicy=DefaultPullPolicy())
Caused by: com.github.dockerjava.api.exception.NotFoundException: 
{"message":"No such image: testcontainersofficial/ryuk:0.3.0"}


[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   FlumeSinkTest>FlumeServerTest.start:41 » ContainerLaunch Container startup fai...
[ERROR]   FlumeUtilsTest>FlumeServerTest.start:41 » ContainerLaunch Container startup fa...
[ERROR]   FlumeUtilsTest>FlumeServerTest.start:41 » ContainerLaunch Container startup fa...
[INFO] 
[ERROR] Tests run: 3, Failures: 0, Errors: 3, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.352 s
[INFO] Finished at: 2021-05-12T13:34:52+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.1:test (default-test) on project flink-connector-flume_2.11: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ramin/Developer/bahir-flink/flink-connector-flume/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```