### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 
     <slf4j.version>1.7.16</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
 
     <!-- Flink version -->
     <flink.version>1.12.2</flink.version>


### PR DESCRIPTION
2.0 <= Apache log4j2 <= 2.14.1 have a RCE zero day.
https://www.lunasec.io/docs/blog/log4j-zero-day/