### PR TITLE
[BAHIR-294] Bump log4j2 version to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 
     <slf4j.version>1.7.16</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
 
     <!-- Flink version -->
     <flink.version>1.12.2</flink.version>


### PR DESCRIPTION
to fix CVE-2021-44228 and CVE-2021-45105
Although there is no place to use, we can prevent it in advance.