### PR TITLE
Remove unnecessary jar packages commons-io 2.4

### DIFF
--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -55,12 +55,26 @@ under the License.
             <version>${jedis.version}</version>
         </dependency>
 
+        <!-- embedded-redis -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.github.kstyrc</groupId>
             <artifactId>embedded-redis</artifactId>
             <version>0.6</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <!-- end of embedded-redis -->
 
         <dependency>
             <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
flink-connector-redis using embedded-redis (version 0.6) for test. Although the scope is specified as test in the pom file, embedded-redis depends on common-io (version 2.4). Due to the transitivity of the dependency, the flink-connector-redis package depends on the unused common-io (version 2.4).
The common-io jar package needs to be excluded from the pom file.

[issue](https://issues.apache.org/jira/browse/BAHIR-298)