### PR TITLE
[BAHIR-299] Replace _2.11 with _${scala.binary.version}

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,13 +20,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>org.apache.bahir</groupId>
-    <artifactId>bahir-flink-assembly_2.11</artifactId>
+    <artifactId>bahir-flink-assembly_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
     <name>Apache Bahir - Flink Extensions Distribution</name>
     <url>http://bahir.apache.org/</url>

--- a/flink-connector-activemq/pom.xml
+++ b/flink-connector-activemq/pom.xml
@@ -23,12 +23,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-connector-activemq_2.11</artifactId>
+    <artifactId>flink-connector-activemq_${scala.binary.version}</artifactId>
     <name>flink-connector-activemq</name>
 
     <packaging>jar</packaging>

--- a/flink-connector-akka/pom.xml
+++ b/flink-connector-akka/pom.xml
@@ -23,12 +23,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>flink-connector-akka_2.11</artifactId>
+    <artifactId>flink-connector-akka_${scala.binary.version}</artifactId>
     <name>flink-connector-akka</name>
     <url>http://bahir.apache.org/</url>
     <packaging>jar</packaging>

--- a/flink-connector-flume/pom.xml
+++ b/flink-connector-flume/pom.xml
@@ -23,12 +23,12 @@ under the License.
 
 	<parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-	<artifactId>flink-connector-flume_2.11</artifactId>
+	<artifactId>flink-connector-flume_${scala.binary.version}</artifactId>
 	<name>flink-connector-flume</name>
 
 	<packaging>jar</packaging>

--- a/flink-connector-influxdb/pom.xml
+++ b/flink-connector-influxdb/pom.xml
@@ -24,12 +24,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-connector-influxdb_2.11</artifactId>
+    <artifactId>flink-connector-influxdb_${scala.binary.version}</artifactId>
     <name>flink-connector-influxdb</name>
 
     <packaging>jar</packaging>

--- a/flink-connector-influxdb2/pom.xml
+++ b/flink-connector-influxdb2/pom.xml
@@ -25,12 +25,12 @@ under the License.
 
   <parent>
     <groupId>org.apache.bahir</groupId>
-    <artifactId>bahir-flink-parent_2.11</artifactId>
+    <artifactId>bahir-flink-parent</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>flink-connector-influxdb2_2.11</artifactId>
+  <artifactId>flink-connector-influxdb2_${scala.binary.version}</artifactId>
   <name>flink-connector-influxdb2</name>
 
   <packaging>jar</packaging>

--- a/flink-connector-kudu/pom.xml
+++ b/flink-connector-kudu/pom.xml
@@ -20,12 +20,12 @@
 
   <parent>
     <groupId>org.apache.bahir</groupId>
-    <artifactId>bahir-flink-parent_2.11</artifactId>
+    <artifactId>bahir-flink-parent</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>flink-connector-kudu_2.11</artifactId>
+  <artifactId>flink-connector-kudu_${scala.binary.version}</artifactId>
   <name>flink-connector-kudu</name>
   <packaging>jar</packaging>
 

--- a/flink-connector-netty/pom.xml
+++ b/flink-connector-netty/pom.xml
@@ -20,12 +20,12 @@
 
   <parent>
     <groupId>org.apache.bahir</groupId>
-    <artifactId>bahir-flink-parent_2.11</artifactId>
+    <artifactId>bahir-flink-parent</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>flink-connector-netty_2.11</artifactId>
+  <artifactId>flink-connector-netty_${scala.binary.version}</artifactId>
   <name>flink-connector-netty</name>
   <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>

--- a/flink-connector-pinot/pom.xml
+++ b/flink-connector-pinot/pom.xml
@@ -25,12 +25,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-connector-pinot_2.11</artifactId>
+    <artifactId>flink-connector-pinot_${scala.binary.version}</artifactId>
     <name>flink-connector-pinot</name>
 
 

--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -23,12 +23,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-connector-redis_2.11</artifactId>
+    <artifactId>flink-connector-redis_${scala.binary.version}</artifactId>
     <name>flink-connector-redis</name>
 
     <packaging>jar</packaging>

--- a/flink-library-siddhi/pom.xml
+++ b/flink-library-siddhi/pom.xml
@@ -20,14 +20,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.bahir</groupId>
-        <artifactId>bahir-flink-parent_2.11</artifactId>
+        <artifactId>bahir-flink-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flink-library-siddhi_2.11</artifactId>
+    <artifactId>flink-library-siddhi_${scala.binary.version}</artifactId>
     <name>flink-library-siddhi</name>
 
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <version>24</version>
   </parent>
   <groupId>org.apache.bahir</groupId>
-  <artifactId>bahir-flink-parent_2.11</artifactId>
+  <artifactId>bahir-flink-parent</artifactId>
   <version>1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Bahir for Apache Flink - Parent POM</name>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BAHIR-299

When use scala-2.12, maven artifactId should result in _2.12, but a lot of bahir-flink code is hardcoded to _2.11. Using _${scala.binary.version} is better.
