### PR TITLE
Bump redis version to 4.2.9

### DIFF
--- a/flink-connector-redis/pom.xml
+++ b/flink-connector-redis/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <name>flink-connector-redis</name>
 
     <properties>
-        <jedis.version>2.9.0</jedis.version>
+        <jedis.version>4.2.3</jedis.version>
     </properties>
 
     <dependencyManagement>

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -46,6 +46,7 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
         this.jedisCluster = jedisCluster;
     }
 
+    @Override
     public void open() {}
 
     @Override

--- a/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
+++ b/flink-connector-redis/src/main/java/org/apache/flink/streaming/connectors/redis/common/container/RedisClusterContainer.java
@@ -46,15 +46,7 @@ public class RedisClusterContainer implements RedisCommandsContainer, Closeable 
         this.jedisCluster = jedisCluster;
     }
 
-    @Override
-    public void open() throws Exception {
-
-        // echo() tries to open a connection and echos back the
-        // message passed as argument. Here we use it to monitor
-        // if we can communicate with the cluster.
-
-        jedisCluster.echo("Test");
-    }
+    public void open() {}
 
     @Override
     public void hset(final String key, final String hashField, final String value, final Integer ttl) {

--- a/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkITCase.java
+++ b/flink-connector-redis/src/test/java/org/apache/flink/streaming/connectors/redis/RedisSinkITCase.java
@@ -69,7 +69,7 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis List Data Type");
 
-        assertEquals(NUM_ELEMENTS, jedis.llen(REDIS_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.llen(REDIS_KEY));
 
         jedis.del(REDIS_KEY);
     }
@@ -83,7 +83,7 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis Set Data Type");
 
-        assertEquals(NUM_ELEMENTS, jedis.scard(REDIS_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.scard(REDIS_KEY));
 
         jedis.del(REDIS_KEY);
     }
@@ -97,8 +97,8 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis Set Data Type With TTL");
 
-        assertEquals(TEST_MESSAGE_LENGTH, jedis.strlen(REDIS_KEY));
-        assertEquals(REDIS_TTL_IN_SECS, jedis.ttl(REDIS_KEY));
+        assertEquals(TEST_MESSAGE_LENGTH.longValue(), jedis.strlen(REDIS_KEY));
+        assertEquals(REDIS_TTL_IN_SECS.longValue(), jedis.ttl(REDIS_KEY));
 
         jedis.del(REDIS_KEY);
     }
@@ -126,7 +126,7 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisZaddSink);
         env.execute("Test ZADD");
 
-        assertEquals(NUM_ELEMENTS, jedis.zcard(REDIS_ADDITIONAL_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.zcard(REDIS_ADDITIONAL_KEY));
 
         RedisSink<Tuple2<String, String>> redisZremSink = new RedisSink<>(jedisPoolConfig,
                 new RedisAdditionalDataMapper(RedisCommand.ZREM));
@@ -134,7 +134,7 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisZremSink);
         env.execute("Test ZREM");
 
-        assertEquals(ZERO, jedis.zcard(REDIS_ADDITIONAL_KEY));
+        assertEquals(ZERO.longValue(), jedis.zcard(REDIS_ADDITIONAL_KEY));
 
         jedis.del(REDIS_ADDITIONAL_KEY);
     }
@@ -148,8 +148,8 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis Hash Data Type");
 
-        assertEquals(NUM_ELEMENTS, jedis.hlen(REDIS_ADDITIONAL_KEY));
-        assertEquals(REDIS_NOT_ASSOCIATED_EXPIRE_FLAG, jedis.ttl(REDIS_ADDITIONAL_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.hlen(REDIS_ADDITIONAL_KEY));
+        assertEquals(REDIS_NOT_ASSOCIATED_EXPIRE_FLAG.longValue(), jedis.ttl(REDIS_ADDITIONAL_KEY));
 
         jedis.del(REDIS_ADDITIONAL_KEY);
     }
@@ -163,8 +163,8 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis Hash Data Type");
 
-        assertEquals(NUM_ELEMENTS, jedis.hlen(REDIS_ADDITIONAL_KEY));
-        assertEquals(REDIS_TTL_IN_SECS, jedis.ttl(REDIS_ADDITIONAL_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.hlen(REDIS_ADDITIONAL_KEY));
+        assertEquals(REDIS_TTL_IN_SECS.longValue(), jedis.ttl(REDIS_ADDITIONAL_KEY));
 
         jedis.del(REDIS_ADDITIONAL_KEY);
     }
@@ -178,8 +178,8 @@ public class RedisSinkITCase extends RedisITCaseBase {
         source.addSink(redisSink);
         env.execute("Test Redis Hash Data Type 2");
 
-        assertEquals(NUM_ELEMENTS, jedis.hlen(REDIS_ADDITIONAL_KEY));
-        assertEquals(REDIS_TTL_IN_SECS, jedis.ttl(REDIS_ADDITIONAL_KEY));
+        assertEquals(NUM_ELEMENTS.longValue(), jedis.hlen(REDIS_ADDITIONAL_KEY));
+        assertEquals(REDIS_TTL_IN_SECS.longValue(), jedis.ttl(REDIS_ADDITIONAL_KEY));
 
         jedis.del(REDIS_ADDITIONAL_KEY);
     }


### PR DESCRIPTION
Trying to expedite this change

https://github.com/apache/bahir-flink/pull/155

Splitting #155 into two separate changes.

cc @eskabetxe 