### PR TITLE
[BAHIR-321] Make KuduFilterInfo handle String literals

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/connector/KuduFilterInfo.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/connector/KuduFilterInfo.java
@@ -17,6 +17,7 @@
 package org.apache.flink.connectors.kudu.connector;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.binary.BinaryStringData;
 
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Schema;
@@ -65,7 +66,8 @@ public class KuduFilterInfo implements Serializable {
 
         switch (column.getType()) {
             case STRING:
-                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (String) this.value);
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison,
+                        (this.value instanceof BinaryStringData) ? this.value.toString() : (String) this.value);
                 break;
             case FLOAT:
                 predicate = KuduPredicate.newComparisonPredicate(column, comparison, (float) this.value);

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/table/function/lookup/KuduRowDataLookupFunction.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/table/function/lookup/KuduRowDataLookupFunction.java
@@ -178,9 +178,11 @@ public class KuduRowDataLookupFunction extends TableFunction<RowData> {
         if (null != this.kuduReader) {
             try {
                 this.kuduReader.close();
-                this.cache.cleanUp();
-                // help gc
-                this.cache = null;
+                if (cache != null) {
+                    this.cache.cleanUp();
+                    // help gc
+                    this.cache = null;
+                }
                 this.kuduReader = null;
             } catch (IOException e) {
                 // ignore exception when close.

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connectors/kudu/connector/KuduFilterInfoTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connectors/kudu/connector/KuduFilterInfoTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connectors.kudu.connector;
+
+import org.apache.flink.table.data.binary.BinaryStringData;
+
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class KuduFilterInfoTest {
+
+    @Test
+    void testKuduFilterInfoWithBinaryStringData() {
+        String filterValue = "someValue";
+
+        KuduFilterInfo kuduFilterInfo = KuduFilterInfo.Builder.create("col")
+                .equalTo(BinaryStringData.fromString(filterValue))
+                .build();
+
+        ColumnSchema colSchema = new ColumnSchema.ColumnSchemaBuilder("col", Type.STRING).build();
+        assertDoesNotThrow(() -> kuduFilterInfo.toPredicate(colSchema));
+    }
+
+}

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connectors/kudu/connector/KuduTestBase.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connectors/kudu/connector/KuduTestBase.java
@@ -261,7 +261,7 @@ public class KuduTestBase {
             });
             kuduWriter.close();
         } catch (Exception e) {
-            Assertions.fail();
+            Assertions.fail(e.getMessage());
         }
     }
 


### PR DESCRIPTION
The KuduFilterInfo's conversion to a KuduPredicate was failing when a string literal was provided (e.g. `WHERE col = 'value'`) because its type is `BinaryStringData`. Instead of trying to cast it to a String, we can use the `toString` method, which should work for every class.