### PR TITLE
BAHIR-324  JobManager created a kuduReader that was not closed, resulting in an increase in server handles

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/format/AbstractKuduInputFormat.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/format/AbstractKuduInputFormat.java
@@ -104,6 +104,13 @@ public abstract class AbstractKuduInputFormat<T> extends RichInputFormat<T, Kudu
         }
     }
 
+    private void closeKuduReader() throws IOException {
+        if (kuduReader != null) {
+            kuduReader.close();
+            kuduReader = null;
+        }
+    }
+
     @Override
     public void close() throws IOException {
         if (resultIterator != null) {
@@ -113,10 +120,7 @@ public abstract class AbstractKuduInputFormat<T> extends RichInputFormat<T, Kudu
                 e.printStackTrace();
             }
         }
-        if (kuduReader != null) {
-            kuduReader.close();
-            kuduReader = null;
-        }
+        closeKuduReader();
     }
 
     @Override
@@ -131,8 +135,12 @@ public abstract class AbstractKuduInputFormat<T> extends RichInputFormat<T, Kudu
 
     @Override
     public KuduInputSplit[] createInputSplits(int minNumSplits) throws IOException {
-        startKuduReader();
-        return kuduReader.createInputSplits(minNumSplits);
+        try {
+            startKuduReader();
+            return kuduReader.createInputSplits(minNumSplits);
+        } finally {
+            closeKuduReader();
+        }
     }
 
     @Override

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/table/function/lookup/KuduRowDataLookupFunction.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connectors/kudu/table/function/lookup/KuduRowDataLookupFunction.java
@@ -107,7 +107,7 @@ public class KuduRowDataLookupFunction extends TableFunction<RowData> {
                 ArrayList<RowData> rows = new ArrayList<>();
                 for (KuduInputSplit inputSplit : inputSplits) {
                     KuduReaderIterator<RowData> scanner = kuduReader.scanner(inputSplit.getScanToken());
-                    // 没有启用cache
+                    // not use cache
                     if (cache == null) {
                         while (scanner.hasNext()) {
                             collect(scanner.next());


### PR DESCRIPTION
# ISSUE Location
[ISSUE BAHIR-324](https://issues.apache.org/jira/projects/BAHIR/issues/BAHIR-324?filter=allopenissues&orderby=priority+DESC%2C+updated+DESC)
# Problem
When JobManager starts, the ExecutionJobVertex constructor calls the AbstractKuduInputFormat#createInputSplits method, Causes the KuduReader object to create the KuduClient and KuduSession objects, but ExecutionJobVertex does not call the Kudureader #close() method with the display, causing the Kudu-related handle to remain open after the Flink task is closed. As a result, the number of server handles increases with the number of Flink tasks. As a result, the entire server becomes unavailable